### PR TITLE
feat: add JSON/YAML workflow test fixtures

### DIFF
--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -7,7 +7,7 @@
 
 - [x] T001 Create package layout for core, web component, and host client modules in `packages/`
 - [x] T002 Configure baseline toolchain in repo config files (Node.js 24 LTS, `pnpm@10.30.3`, `@biomejs/biome@2.4.5`, `vitest@4.0.18`, `@playwright/test@1.58.2`)
-- [ ] T003 [P] Add fixtures for JSON and YAML workflow sources in `tests/fixtures/`
+- [x] T003 [P] Add fixtures for JSON and YAML workflow sources in `tests/fixtures/`
 
 ## Phase 2: Foundational (Blocking Prerequisites)
 

--- a/tests/fixtures/invalid/missing-document.yaml
+++ b/tests/fixtures/invalid/missing-document.yaml
@@ -1,0 +1,9 @@
+# Invalid fixture: missing required top-level 'document' field.
+# Expected behaviour: schema validation MUST reject this workflow.
+# Schema violation: 'document' is required by the Serverless Workflow DSL schema.
+do:
+  - fetchData:
+      call: http
+      with:
+        method: get
+        endpoint: https://api.example.com/data

--- a/tests/fixtures/invalid/missing-required-document-fields.yaml
+++ b/tests/fixtures/invalid/missing-required-document-fields.yaml
@@ -1,0 +1,11 @@
+# Invalid fixture: 'document' block is present but missing required fields.
+# Required fields omitted: 'dsl', 'namespace', 'name', 'version'.
+# Expected behaviour: schema validation MUST reject this workflow.
+document:
+  description: This document block is missing all required fields
+do:
+  - fetchData:
+      call: http
+      with:
+        method: get
+        endpoint: https://api.example.com/data

--- a/tests/fixtures/invalid/wrong-type-for-do.yaml
+++ b/tests/fixtures/invalid/wrong-type-for-do.yaml
@@ -1,0 +1,14 @@
+# Invalid fixture: 'do' field has wrong type (object instead of array).
+# Expected behaviour: schema validation MUST reject this workflow.
+# Schema violation: 'do' must be an ordered array of named task entries.
+document:
+  dsl: '1.0.0'
+  namespace: fixtures
+  name: wrong-do-type
+  version: '1.0.0'
+do:
+  fetchData:
+    call: http
+    with:
+      method: get
+      endpoint: https://api.example.com/data

--- a/tests/fixtures/valid/multi-task.json
+++ b/tests/fixtures/valid/multi-task.json
@@ -1,0 +1,83 @@
+{
+  "document": {
+    "dsl": "1.0.0",
+    "namespace": "fixtures",
+    "name": "multi-task-order",
+    "version": "1.0.0",
+    "metadata": {
+      "description": "Multi-step order processing workflow with special chars: <>&\""
+    }
+  },
+  "input": {
+    "schema": {
+      "format": "json",
+      "document": {
+        "type": "object",
+        "required": ["orderId", "customerId"],
+        "properties": {
+          "orderId": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number",
+            "minimum": 0
+          }
+        }
+      }
+    }
+  },
+  "do": [
+    {
+      "validateOrder": {
+        "call": "http",
+        "with": {
+          "method": "post",
+          "endpoint": "https://api.example.com/orders/validate",
+          "body": {
+            "orderId": "${ .orderId }",
+            "customerId": "${ .customerId }"
+          }
+        },
+        "export": {
+          "as": {
+            "validationResult": "${ . }"
+          }
+        }
+      }
+    },
+    {
+      "chargePayment": {
+        "call": "http",
+        "with": {
+          "method": "post",
+          "endpoint": "https://api.example.com/payments/charge",
+          "body": {
+            "orderId": "${ .orderId }",
+            "amount": "${ .amount }"
+          }
+        },
+        "export": {
+          "as": {
+            "paymentId": "${ .paymentId }"
+          }
+        }
+      }
+    },
+    {
+      "fulfillOrder": {
+        "call": "http",
+        "with": {
+          "method": "post",
+          "endpoint": "https://api.example.com/orders/fulfill",
+          "body": {
+            "orderId": "${ .orderId }",
+            "paymentId": "${ .paymentId }"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/valid/multi-task.yaml
+++ b/tests/fixtures/valid/multi-task.yaml
@@ -1,0 +1,60 @@
+# Multi-step order processing workflow.
+# Tests sequential task chaining, input/output export, and special characters in metadata.
+# Edge case: metadata description contains XML/HTML special characters: <>&"
+document:
+  dsl: '1.0.0'
+  namespace: fixtures
+  name: multi-task-order
+  version: '1.0.0'
+  metadata:
+    description: 'Multi-step order processing workflow with special chars: <>&"'
+input:
+  schema:
+    format: json
+    document:
+      type: object
+      required:
+        - orderId
+        - customerId
+      properties:
+        orderId:
+          type: string
+        customerId:
+          type: string
+        amount:
+          type: number
+          minimum: 0
+do:
+  # Step 1: validate the order before charging
+  - validateOrder:
+      call: http
+      with:
+        method: post
+        endpoint: https://api.example.com/orders/validate
+        body:
+          orderId: ${ .orderId }
+          customerId: ${ .customerId }
+      export:
+        as:
+          validationResult: ${ . }
+  # Step 2: charge payment using the validated order amount
+  - chargePayment:
+      call: http
+      with:
+        method: post
+        endpoint: https://api.example.com/payments/charge
+        body:
+          orderId: ${ .orderId }
+          amount: ${ .amount }
+      export:
+        as:
+          paymentId: ${ .paymentId }
+  # Step 3: fulfill the order once payment is confirmed
+  - fulfillOrder:
+      call: http
+      with:
+        method: post
+        endpoint: https://api.example.com/orders/fulfill
+        body:
+          orderId: ${ .orderId }
+          paymentId: ${ .paymentId }

--- a/tests/fixtures/valid/simple.json
+++ b/tests/fixtures/valid/simple.json
@@ -1,0 +1,34 @@
+{
+  "document": {
+    "dsl": "1.0.0",
+    "namespace": "fixtures",
+    "name": "simple-http-call",
+    "version": "1.0.0"
+  },
+  "input": {
+    "schema": {
+      "format": "json",
+      "document": {
+        "type": "object",
+        "required": ["userId"],
+        "properties": {
+          "userId": {
+            "type": "string",
+            "description": "The ID of the user to fetch"
+          }
+        }
+      }
+    }
+  },
+  "do": [
+    {
+      "fetchUser": {
+        "call": "http",
+        "with": {
+          "method": "get",
+          "endpoint": "https://api.example.com/users/{userId}"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/valid/simple.yaml
+++ b/tests/fixtures/valid/simple.yaml
@@ -1,0 +1,24 @@
+# Simple single-task workflow fixture.
+# Used for basic round-trip validation (JSON <-> YAML).
+document:
+  dsl: '1.0.0'
+  namespace: fixtures
+  name: simple-http-call
+  version: '1.0.0'
+input:
+  schema:
+    format: json
+    document:
+      type: object
+      required:
+        - userId
+      properties:
+        userId:
+          type: string
+          description: The ID of the user to fetch
+do:
+  - fetchUser:
+      call: http
+      with:
+        method: get
+        endpoint: https://api.example.com/users/{userId}

--- a/tests/fixtures/valid/with-branches.json
+++ b/tests/fixtures/valid/with-branches.json
@@ -1,0 +1,89 @@
+{
+  "document": {
+    "dsl": "1.0.0",
+    "namespace": "fixtures",
+    "name": "parallel-notifications",
+    "version": "1.0.0"
+  },
+  "input": {
+    "schema": {
+      "format": "json",
+      "document": {
+        "type": "object",
+        "required": ["userId", "message"],
+        "properties": {
+          "userId": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string",
+            "description": "Notification message (supports Unicode: \u00e9\u00e0\u00fc\u4e2d\u6587)"
+          }
+        }
+      }
+    }
+  },
+  "do": [
+    {
+      "sendNotifications": {
+        "fork": {
+          "compete": false,
+          "branches": [
+            {
+              "sendEmail": {
+                "call": "http",
+                "with": {
+                  "method": "post",
+                  "endpoint": "https://api.example.com/notify/email",
+                  "body": {
+                    "userId": "${ .userId }",
+                    "message": "${ .message }"
+                  }
+                }
+              }
+            },
+            {
+              "sendSms": {
+                "call": "http",
+                "with": {
+                  "method": "post",
+                  "endpoint": "https://api.example.com/notify/sms",
+                  "body": {
+                    "userId": "${ .userId }",
+                    "message": "${ .message }"
+                  }
+                }
+              }
+            },
+            {
+              "sendPush": {
+                "call": "http",
+                "with": {
+                  "method": "post",
+                  "endpoint": "https://api.example.com/notify/push",
+                  "body": {
+                    "userId": "${ .userId }",
+                    "message": "${ .message }"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "logResult": {
+        "call": "http",
+        "with": {
+          "method": "post",
+          "endpoint": "https://api.example.com/audit/log",
+          "body": {
+            "userId": "${ .userId }",
+            "action": "notifications_sent"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/valid/with-branches.yaml
+++ b/tests/fixtures/valid/with-branches.yaml
@@ -1,0 +1,61 @@
+# Parallel notification workflow with fork (branching).
+# Tests fork task with multiple concurrent branches and Unicode characters.
+# Edge case: message field description contains Unicode: éàü中文
+document:
+  dsl: '1.0.0'
+  namespace: fixtures
+  name: parallel-notifications
+  version: '1.0.0'
+input:
+  schema:
+    format: json
+    document:
+      type: object
+      required:
+        - userId
+        - message
+      properties:
+        userId:
+          type: string
+        message:
+          type: string
+          # Unicode edge case: éàü中文
+          description: 'Notification message (supports Unicode: éàü中文)'
+do:
+  - sendNotifications:
+      fork:
+        # All three branches run concurrently; results are collected as an array
+        compete: false
+        branches:
+          - sendEmail:
+              call: http
+              with:
+                method: post
+                endpoint: https://api.example.com/notify/email
+                body:
+                  userId: ${ .userId }
+                  message: ${ .message }
+          - sendSms:
+              call: http
+              with:
+                method: post
+                endpoint: https://api.example.com/notify/sms
+                body:
+                  userId: ${ .userId }
+                  message: ${ .message }
+          - sendPush:
+              call: http
+              with:
+                method: post
+                endpoint: https://api.example.com/notify/push
+                body:
+                  userId: ${ .userId }
+                  message: ${ .message }
+  - logResult:
+      call: http
+      with:
+        method: post
+        endpoint: https://api.example.com/audit/log
+        body:
+          userId: ${ .userId }
+          action: notifications_sent


### PR DESCRIPTION
## Summary

- Creates `tests/fixtures/valid/` with three Serverless Workflow DSL 1.0.0 definitions in both JSON and YAML:
  - `simple` — single HTTP call, covers minimal valid workflow
  - `multi-task` — sequential order processing with input/output export and special-character metadata (`<>&"`)
  - `with-branches` — parallel fork with three concurrent notification branches and Unicode in descriptions
- Creates `tests/fixtures/invalid/` with three fixtures that schema validation must reject:
  - `missing-document.yaml` — top-level `document` field absent
  - `missing-required-document-fields.yaml` — `document` present but `dsl`, `namespace`, `name`, `version` all missing
  - `wrong-type-for-do.yaml` — `do` is a plain object instead of an ordered array
- Marks T003 complete in `specs/001-visual-authoring-mvp/tasks.md`

## Test plan

- [ ] Valid fixtures parse without errors using `@serverlessworkflow/sdk` (`Classes.Workflow.deserialize`)
- [ ] Invalid fixtures throw / return invalid when passed to `validate('Workflow', …)`
- [ ] YAML fixtures with comments, `<>&"`, and Unicode (`éàü中文`) survive a JSON→YAML→JSON round-trip with semantic equivalence (SC-003)

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)