### PR TITLE
feat: implement diagnostics model and types in editor-core

### DIFF
--- a/packages/editor-core/src/diagnostics/helpers.ts
+++ b/packages/editor-core/src/diagnostics/helpers.ts
@@ -1,0 +1,61 @@
+import type { DiagnosticSeverity, DiagnosticsCollection, ValidationDiagnostic } from "./types.js";
+import { compareSeverity } from "./severity.js";
+
+/**
+ * Filters a {@link DiagnosticsCollection} to only include diagnostics whose
+ * severity is greater than or equal to the given minimum severity.
+ *
+ * @param diagnostics - Source collection to filter.
+ * @param minSeverity - Minimum severity level to include.
+ * @returns A new array containing only matching diagnostics.
+ */
+export function filterBySeverity(
+  diagnostics: DiagnosticsCollection,
+  minSeverity: DiagnosticSeverity,
+): DiagnosticsCollection {
+  return diagnostics.filter(
+    (d) => compareSeverity(d.severity, minSeverity) >= 0,
+  );
+}
+
+/**
+ * Returns `true` if the collection contains at least one diagnostic with
+ * severity `"error"`.
+ *
+ * @param diagnostics - Collection to inspect.
+ */
+export function hasErrors(diagnostics: DiagnosticsCollection): boolean {
+  return diagnostics.some((d) => d.severity === "error");
+}
+
+/**
+ * Serializes a {@link DiagnosticsCollection} to a JSON string.
+ *
+ * The resulting string is suitable for cross-boundary transmission to host
+ * applications. The collection can be reconstructed with `JSON.parse`.
+ *
+ * @param diagnostics - Collection to serialize.
+ * @returns JSON string representation.
+ */
+export function serializeDiagnostics(diagnostics: DiagnosticsCollection): string {
+  return JSON.stringify(diagnostics);
+}
+
+/**
+ * Creates a {@link ValidationDiagnostic} object, providing a convenient
+ * factory with named parameters.
+ *
+ * @param ruleId - Identifier for the rule that produced this diagnostic.
+ * @param severity - Severity level.
+ * @param message - Human-readable description of the issue.
+ * @param location - Pointer or path reference within the source.
+ * @returns A new `ValidationDiagnostic` instance.
+ */
+export function createDiagnostic(
+  ruleId: string,
+  severity: DiagnosticSeverity,
+  message: string,
+  location: string,
+): ValidationDiagnostic {
+  return { ruleId, severity, message, location };
+}

--- a/packages/editor-core/src/diagnostics/index.ts
+++ b/packages/editor-core/src/diagnostics/index.ts
@@ -1,0 +1,3 @@
+export type { DiagnosticSeverity, DiagnosticsCollection, ValidationDiagnostic } from "./types.js";
+export { SEVERITY_ORDER, compareSeverity, maxSeverity, severityRank } from "./severity.js";
+export { createDiagnostic, filterBySeverity, hasErrors, serializeDiagnostics } from "./helpers.js";

--- a/packages/editor-core/src/diagnostics/severity.ts
+++ b/packages/editor-core/src/diagnostics/severity.ts
@@ -1,0 +1,54 @@
+import type { DiagnosticSeverity } from "./types.js";
+
+/**
+ * Numeric ordering for {@link DiagnosticSeverity} levels.
+ * Higher numbers indicate greater severity.
+ *
+ * - `error`   → 2
+ * - `warning` → 1
+ * - `info`    → 0
+ */
+export const SEVERITY_ORDER: Readonly<Record<DiagnosticSeverity, number>> = {
+  error: 2,
+  warning: 1,
+  info: 0,
+};
+
+/**
+ * Returns the numeric severity rank for the given severity level.
+ *
+ * @param severity - The severity level to rank.
+ * @returns A number where higher values indicate greater severity.
+ */
+export function severityRank(severity: DiagnosticSeverity): number {
+  return SEVERITY_ORDER[severity];
+}
+
+/**
+ * Compares two severity levels.
+ *
+ * @param a - First severity level.
+ * @param b - Second severity level.
+ * @returns A positive number if `a` is more severe than `b`, negative if
+ *          less severe, or `0` if equal.
+ */
+export function compareSeverity(
+  a: DiagnosticSeverity,
+  b: DiagnosticSeverity,
+): number {
+  return SEVERITY_ORDER[a] - SEVERITY_ORDER[b];
+}
+
+/**
+ * Returns the more severe of two severity levels.
+ *
+ * @param a - First severity level.
+ * @param b - Second severity level.
+ * @returns The severity level with the higher rank.
+ */
+export function maxSeverity(
+  a: DiagnosticSeverity,
+  b: DiagnosticSeverity,
+): DiagnosticSeverity {
+  return SEVERITY_ORDER[a] >= SEVERITY_ORDER[b] ? a : b;
+}

--- a/packages/editor-core/src/diagnostics/types.ts
+++ b/packages/editor-core/src/diagnostics/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Severity level of a validation diagnostic.
+ *
+ * Ordered from most severe to least severe:
+ * `error` > `warning` > `info`
+ */
+export type DiagnosticSeverity = "error" | "warning" | "info";
+
+/**
+ * A single validation diagnostic produced by the editor core.
+ *
+ * All fields are JSON-safe primitives so the diagnostic can be serialized
+ * and consumed by host applications without any transformation.
+ */
+export interface ValidationDiagnostic {
+  /** Identifier for the rule that produced this diagnostic. */
+  ruleId: string;
+  /** Severity level of the diagnostic. */
+  severity: DiagnosticSeverity;
+  /** Human-readable description of the issue. */
+  message: string;
+  /**
+   * Pointer or path reference indicating where in the source the issue
+   * was found (e.g. a JSON Pointer string or dot-separated property path).
+   */
+  location: string;
+}
+
+/**
+ * An ordered collection of {@link ValidationDiagnostic} entries.
+ * The array is JSON-serializable as-is.
+ */
+export type DiagnosticsCollection = ValidationDiagnostic[];

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./diagnostics/index.js";

--- a/packages/editor-core/tests/diagnostics.test.ts
+++ b/packages/editor-core/tests/diagnostics.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  SEVERITY_ORDER,
+  compareSeverity,
+  createDiagnostic,
+  filterBySeverity,
+  hasErrors,
+  maxSeverity,
+  serializeDiagnostics,
+  severityRank,
+} from "../src/diagnostics/index.js";
+import type { DiagnosticsCollection, ValidationDiagnostic } from "../src/diagnostics/index.js";
+
+describe("ValidationDiagnostic — type construction", () => {
+  it("creates a valid diagnostic via createDiagnostic", () => {
+    const d: ValidationDiagnostic = createDiagnostic(
+      "required-field",
+      "error",
+      "Field 'name' is required",
+      "/do/0/name",
+    );
+
+    expect(d.ruleId).toBe("required-field");
+    expect(d.severity).toBe("error");
+    expect(d.message).toBe("Field 'name' is required");
+    expect(d.location).toBe("/do/0/name");
+  });
+
+  it("accepts all three severity levels", () => {
+    const error = createDiagnostic("r1", "error", "msg", "/");
+    const warning = createDiagnostic("r2", "warning", "msg", "/");
+    const info = createDiagnostic("r3", "info", "msg", "/");
+
+    expect(error.severity).toBe("error");
+    expect(warning.severity).toBe("warning");
+    expect(info.severity).toBe("info");
+  });
+});
+
+describe("Severity ordering", () => {
+  it("SEVERITY_ORDER assigns correct ranks", () => {
+    expect(SEVERITY_ORDER.error).toBeGreaterThan(SEVERITY_ORDER.warning);
+    expect(SEVERITY_ORDER.warning).toBeGreaterThan(SEVERITY_ORDER.info);
+  });
+
+  it("severityRank returns the same value as SEVERITY_ORDER", () => {
+    expect(severityRank("error")).toBe(SEVERITY_ORDER.error);
+    expect(severityRank("warning")).toBe(SEVERITY_ORDER.warning);
+    expect(severityRank("info")).toBe(SEVERITY_ORDER.info);
+  });
+
+  it("compareSeverity returns positive when a > b", () => {
+    expect(compareSeverity("error", "warning")).toBeGreaterThan(0);
+    expect(compareSeverity("warning", "info")).toBeGreaterThan(0);
+    expect(compareSeverity("error", "info")).toBeGreaterThan(0);
+  });
+
+  it("compareSeverity returns negative when a < b", () => {
+    expect(compareSeverity("info", "warning")).toBeLessThan(0);
+    expect(compareSeverity("warning", "error")).toBeLessThan(0);
+  });
+
+  it("compareSeverity returns 0 for equal severities", () => {
+    expect(compareSeverity("error", "error")).toBe(0);
+    expect(compareSeverity("warning", "warning")).toBe(0);
+    expect(compareSeverity("info", "info")).toBe(0);
+  });
+
+  it("maxSeverity returns the higher severity", () => {
+    expect(maxSeverity("error", "warning")).toBe("error");
+    expect(maxSeverity("info", "warning")).toBe("warning");
+    expect(maxSeverity("info", "error")).toBe("error");
+    expect(maxSeverity("warning", "warning")).toBe("warning");
+  });
+});
+
+describe("DiagnosticsCollection helpers", () => {
+  const collection: DiagnosticsCollection = [
+    createDiagnostic("r1", "error", "err msg", "/a"),
+    createDiagnostic("r2", "warning", "warn msg", "/b"),
+    createDiagnostic("r3", "info", "info msg", "/c"),
+  ];
+
+  it("filterBySeverity keeps only diagnostics at or above the threshold", () => {
+    const errorsOnly = filterBySeverity(collection, "error");
+    expect(errorsOnly).toHaveLength(1);
+    expect(errorsOnly[0]?.severity).toBe("error");
+
+    const warningsAndAbove = filterBySeverity(collection, "warning");
+    expect(warningsAndAbove).toHaveLength(2);
+
+    const all = filterBySeverity(collection, "info");
+    expect(all).toHaveLength(3);
+  });
+
+  it("hasErrors returns true when collection contains an error", () => {
+    expect(hasErrors(collection)).toBe(true);
+    expect(hasErrors([createDiagnostic("r", "warning", "w", "/")])).toBe(false);
+    expect(hasErrors([])).toBe(false);
+  });
+
+  it("does not mutate the original collection", () => {
+    const copy = [...collection];
+    filterBySeverity(collection, "error");
+    expect(collection).toEqual(copy);
+  });
+});
+
+describe("Serialization", () => {
+  it("serializeDiagnostics produces valid JSON", () => {
+    const collection: DiagnosticsCollection = [
+      createDiagnostic("r1", "error", "Something broke", "/tasks/0"),
+    ];
+
+    const json = serializeDiagnostics(collection);
+    const parsed = JSON.parse(json) as unknown;
+
+    expect(Array.isArray(parsed)).toBe(true);
+    const first = (parsed as ValidationDiagnostic[])[0];
+    expect(first?.ruleId).toBe("r1");
+    expect(first?.severity).toBe("error");
+    expect(first?.message).toBe("Something broke");
+    expect(first?.location).toBe("/tasks/0");
+  });
+
+  it("round-trips an empty collection", () => {
+    const json = serializeDiagnostics([]);
+    expect(JSON.parse(json)).toEqual([]);
+  });
+
+  it("round-trips a multi-diagnostic collection", () => {
+    const collection: DiagnosticsCollection = [
+      createDiagnostic("r1", "error", "e", "/x"),
+      createDiagnostic("r2", "warning", "w", "/y"),
+      createDiagnostic("r3", "info", "i", "/z"),
+    ];
+
+    const parsed = JSON.parse(serializeDiagnostics(collection)) as ValidationDiagnostic[];
+    expect(parsed).toHaveLength(3);
+    expect(parsed[1]?.severity).toBe("warning");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `packages/editor-core/src/diagnostics/` module with four files:
  - `types.ts` — `DiagnosticSeverity`, `ValidationDiagnostic`, `DiagnosticsCollection`
  - `severity.ts` — `SEVERITY_ORDER` map, `severityRank`, `compareSeverity`, `maxSeverity`
  - `helpers.ts` — `createDiagnostic`, `filterBySeverity`, `hasErrors`, `serializeDiagnostics`
  - `index.ts` — re-exports everything
- Creates `packages/editor-core/src/index.ts` as the package entry point
- Adds `packages/editor-core/tests/diagnostics.test.ts` with 14 unit tests

All types are JSON-safe primitives. Severity levels are correctly ordered (error > warning > info). TypeScript build passes with `strict`, `exactOptionalPropertyTypes`, and `noUncheckedIndexedAccess` enabled. All 14 tests pass.

Closes #21

## Test plan

- [x] `pnpm run build` in `packages/editor-core` — passes with no errors
- [x] `npx vitest run --project editor-core` from workspace root — 14/14 tests pass
- [x] Type construction tests validate all severity levels and field shapes
- [x] Severity ordering tests confirm `error > warning > info`
- [x] Serialization tests confirm round-trip JSON fidelity

🤖 Generated with [Claude Code](https://claude.com/claude-code)