### PR TITLE
feat: implement host contract surface types in editor-host-client

### DIFF
--- a/packages/editor-host-client/src/contracts/capabilities.ts
+++ b/packages/editor-host-client/src/contracts/capabilities.ts
@@ -1,0 +1,55 @@
+import type { RendererId } from "./types.js";
+
+/**
+ * Capability snapshot for a specific renderer backend.
+ *
+ * Describes what optional rendering features the active backend supports.
+ * Backward-compatible capability expansion is allowed; hosts must ignore
+ * unknown fields.
+ */
+export interface RendererCapabilitySnapshot {
+  /** Renderer backend identifier. */
+  rendererId: RendererId;
+  /** Semantic version string of the renderer package. */
+  rendererVersion: string;
+  /** Whether the renderer supports third-party node renderer plugins. */
+  supportsNodeRendererPlugins: boolean;
+  /** Whether the renderer supports nested inline graph projection. */
+  supportsNestedInlineProjection: boolean;
+  /** Whether the renderer supports route overlay projection. */
+  supportsRouteOverlayProjection: boolean;
+  /**
+   * Optional list of known rendering limitations for this backend version.
+   * Each entry is a short human-readable string.
+   */
+  knownLimits?: string[];
+}
+
+/**
+ * Full capability snapshot returned by {@link HostEditorContract.getCapabilities}.
+ *
+ * Hosts use this payload to verify compatibility before issuing API calls.
+ * The payload must remain stable across patch releases; only additive changes
+ * are allowed without a `contractVersion` bump.
+ */
+export interface CapabilitySnapshot {
+  /**
+   * Semantic version of the host–editor contract implemented by this bundle.
+   * Follows SemVer; hosts should reject incompatible major versions.
+   */
+  contractVersion: string;
+  /**
+   * Version of the Serverless Workflow specification this editor targets
+   * (e.g. `"0.9"`, `"1.0"`).
+   */
+  targetVersion: string;
+  /**
+   * All Serverless Workflow specification versions this editor can parse and
+   * validate, including `targetVersion`.
+   */
+  supportedVersions: string[];
+  /** Renderer backend compiled into this bundle. */
+  rendererId: RendererId;
+  /** Renderer-specific capability details. */
+  rendererCapabilities: RendererCapabilitySnapshot;
+}

--- a/packages/editor-host-client/src/contracts/events.ts
+++ b/packages/editor-host-client/src/contracts/events.ts
@@ -1,0 +1,105 @@
+import type { DiagnosticsCollection } from "@sw-editor/editor-core";
+import type { EditorSelection, WorkflowSource } from "./types.js";
+
+/**
+ * Stable event name constants for all host–editor contract events.
+ *
+ * Event names are unversioned; compatibility is maintained through explicit
+ * version fields on each payload.
+ */
+export const EditorEventName = {
+  /** Emitted whenever the workflow document changes. */
+  workflowChanged: "workflowChanged",
+  /** Emitted whenever the user's in-editor selection changes. */
+  editorSelectionChanged: "editorSelectionChanged",
+  /** Emitted after each validation pass with the current diagnostics. */
+  editorDiagnosticsChanged: "editorDiagnosticsChanged",
+  /** Emitted when the editor encounters an unrecoverable error. */
+  editorError: "editorError",
+} as const;
+
+/** Union of all valid editor event name strings. */
+export type EditorEventName = (typeof EditorEventName)[keyof typeof EditorEventName];
+
+// ---------------------------------------------------------------------------
+// Event payload types
+// ---------------------------------------------------------------------------
+
+/**
+ * Base fields shared by all event payloads.
+ *
+ * `version` carries the contract version so hosts can detect schema drift
+ * without an out-of-band handshake. `revision` is a monotonically increasing
+ * counter scoped to the current editor instance; hosts may use it to detect
+ * dropped or reordered events.
+ */
+export interface BaseEventPayload {
+  /** Contract version string (SemVer) of the emitting editor bundle. */
+  version: string;
+  /** Monotonically increasing counter, reset to `1` when the editor mounts. */
+  revision: number;
+}
+
+/**
+ * Payload for the {@link EditorEventName.workflowChanged} event.
+ *
+ * Carries the full updated workflow source so the host does not need to call
+ * `exportWorkflowSource` to obtain it.
+ */
+export interface WorkflowChangedPayload extends BaseEventPayload {
+  /** Updated workflow source at the time the event was emitted. */
+  source: WorkflowSource;
+}
+
+/**
+ * Payload for the {@link EditorEventName.editorSelectionChanged} event.
+ *
+ * `selection` is `null` when no graph element is selected (workflow-level
+ * panel state).
+ */
+export interface EditorSelectionChangedPayload extends BaseEventPayload {
+  /** Current selection, or `null` for workflow-level state. */
+  selection: EditorSelection | null;
+}
+
+/**
+ * Payload for the {@link EditorEventName.editorDiagnosticsChanged} event.
+ *
+ * Emitted after every live-validation pass; `diagnostics` replaces the
+ * previous collection in its entirety.
+ */
+export interface EditorDiagnosticsChangedPayload extends BaseEventPayload {
+  /** Complete, up-to-date diagnostics collection after the latest pass. */
+  diagnostics: DiagnosticsCollection;
+}
+
+/**
+ * Payload for the {@link EditorEventName.editorError} event.
+ *
+ * Emitted when the editor encounters an unrecoverable internal error.
+ * The editor may be in a degraded state after this event.
+ */
+export interface EditorErrorPayload extends BaseEventPayload {
+  /** Short machine-readable error code. */
+  code: string;
+  /** Human-readable description of the error. */
+  message: string;
+}
+
+/**
+ * Discriminated map from event name to its payload type.
+ *
+ * Useful for typed event listener registration:
+ * ```ts
+ * editor.addEventListener<EditorEventPayloadMap["workflowChanged"]>(
+ *   EditorEventName.workflowChanged,
+ *   (payload) => { ... },
+ * );
+ * ```
+ */
+export interface EditorEventPayloadMap {
+  [EditorEventName.workflowChanged]: WorkflowChangedPayload;
+  [EditorEventName.editorSelectionChanged]: EditorSelectionChangedPayload;
+  [EditorEventName.editorDiagnosticsChanged]: EditorDiagnosticsChangedPayload;
+  [EditorEventName.editorError]: EditorErrorPayload;
+}

--- a/packages/editor-host-client/src/contracts/index.ts
+++ b/packages/editor-host-client/src/contracts/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Host–editor contract surface types for `@sw-editor/editor-host-client`.
+ *
+ * This module exports all TypeScript interfaces, types, and constants that
+ * define the public contract between a host application and the editor bundle.
+ *
+ * @module contracts
+ */
+export type {
+  CapabilitySnapshot,
+  RendererCapabilitySnapshot,
+} from "./capabilities.js";
+export {
+  EditorEventName,
+} from "./events.js";
+export type {
+  BaseEventPayload,
+  EditorDiagnosticsChangedPayload,
+  EditorErrorPayload,
+  EditorEventPayloadMap,
+  EditorSelectionChangedPayload,
+  WorkflowChangedPayload,
+} from "./events.js";
+export type {
+  ExportWorkflowSourceOptions,
+  ExportWorkflowSourceResult,
+  HostEditorContract,
+  LoadWorkflowSourceInput,
+  ValidateWorkflowOptions,
+  ValidateWorkflowResult,
+} from "./methods.js";
+export type {
+  EdgeSelection,
+  EditorSelection,
+  NodeSelection,
+  RendererId,
+  WorkflowFormat,
+  WorkflowSource,
+} from "./types.js";

--- a/packages/editor-host-client/src/contracts/methods.ts
+++ b/packages/editor-host-client/src/contracts/methods.ts
@@ -1,0 +1,120 @@
+import type { CapabilitySnapshot } from "./capabilities.js";
+import type { EditorSelection, WorkflowSource } from "./types.js";
+
+/**
+ * Input accepted by {@link HostEditorContract.loadWorkflowSource}.
+ */
+export interface LoadWorkflowSourceInput {
+  /** Workflow source to load into the editor. */
+  source: WorkflowSource;
+}
+
+/**
+ * Options accepted by {@link HostEditorContract.exportWorkflowSource}.
+ */
+export interface ExportWorkflowSourceOptions {
+  /**
+   * Desired output format. When omitted the editor uses the format of the
+   * last loaded or saved source.
+   */
+  format?: "json" | "yaml";
+}
+
+/**
+ * Result returned by {@link HostEditorContract.exportWorkflowSource}.
+ */
+export interface ExportWorkflowSourceResult {
+  /** Exported workflow source in the requested format. */
+  source: WorkflowSource;
+}
+
+/**
+ * Options accepted by {@link HostEditorContract.validateWorkflow}.
+ */
+export interface ValidateWorkflowOptions {
+  /**
+   * When `true`, the editor runs a full validation pass and awaits completion
+   * before resolving. When omitted or `false`, behavior is implementation-
+   * defined (typically a scheduled incremental pass).
+   */
+  full?: boolean;
+}
+
+/**
+ * Result returned by {@link HostEditorContract.validateWorkflow}.
+ */
+export interface ValidateWorkflowResult {
+  /** `true` if the workflow has no error-severity diagnostics. */
+  valid: boolean;
+  /** Diagnostic count by severity after the validation pass. */
+  summary: {
+    errors: number;
+    warnings: number;
+    infos: number;
+  };
+}
+
+/**
+ * The synchronous/async contract surface exposed by the editor to the host.
+ *
+ * All method calls are logically atomic from the host's perspective: the
+ * editor resolves each promise after completing the requested operation or
+ * rejects it with a descriptive error.
+ *
+ * Method names are stable; backward-incompatible changes require a
+ * `contractVersion` bump in {@link CapabilitySnapshot}.
+ */
+export interface HostEditorContract {
+  /**
+   * Load a workflow source document into the editor, replacing any current
+   * content.
+   *
+   * @param input - The source document to load.
+   * @returns A promise that resolves when the editor has parsed and projected
+   *   the source into the graph.
+   */
+  loadWorkflowSource(input: LoadWorkflowSourceInput): Promise<void>;
+
+  /**
+   * Export the current workflow as a serialized source document.
+   *
+   * @param options - Optional export settings (e.g. desired format).
+   * @returns A promise that resolves with the serialized source.
+   */
+  exportWorkflowSource(
+    options?: ExportWorkflowSourceOptions,
+  ): Promise<ExportWorkflowSourceResult>;
+
+  /**
+   * Trigger a validation pass on the current workflow.
+   *
+   * The editor always owns validation execution. Hosts use this method to
+   * request an explicit full pass; incremental live validation runs
+   * independently.
+   *
+   * @param options - Optional validation settings.
+   * @returns A promise that resolves with the validation result summary.
+   */
+  validateWorkflow(options?: ValidateWorkflowOptions): Promise<ValidateWorkflowResult>;
+
+  /**
+   * Programmatically set the current in-editor selection.
+   *
+   * Pass `null` to clear the selection and return to workflow-level panel
+   * state.
+   *
+   * @param selection - The element to select, or `null` to clear.
+   * @returns A promise that resolves when the selection has been applied.
+   */
+  setSelection(selection: EditorSelection | null): Promise<void>;
+
+  /**
+   * Retrieve the capability snapshot for the current editor bundle.
+   *
+   * Hosts should call this method once after mount to verify contract and
+   * spec version compatibility before issuing further API calls.
+   *
+   * @returns A promise that resolves with the capability snapshot.
+   */
+  getCapabilities(): Promise<CapabilitySnapshot>;
+}

--- a/packages/editor-host-client/src/contracts/types.ts
+++ b/packages/editor-host-client/src/contracts/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Supported workflow source format identifiers.
+ */
+export type WorkflowFormat = "json" | "yaml";
+
+/**
+ * Raw workflow source as provided by the host or exported by the editor.
+ *
+ * The `content` string must be valid JSON or YAML matching the declared
+ * `format` before it is passed to the editor core for parsing.
+ */
+export interface WorkflowSource {
+  /** Serialization format of the workflow content. */
+  format: WorkflowFormat;
+  /** Raw serialized workflow document. */
+  content: string;
+}
+
+/**
+ * Identifies the renderer backend compiled into the current editor bundle.
+ *
+ * The value is fixed at build time and cannot change for a running instance.
+ */
+export type RendererId = "rete-lit" | "react-flow";
+
+/**
+ * Selection targeting a graph node.
+ */
+export interface NodeSelection {
+  kind: "node";
+  /** Stable identifier of the selected node. */
+  nodeId: string;
+}
+
+/**
+ * Selection targeting a graph edge.
+ */
+export interface EdgeSelection {
+  kind: "edge";
+  /** Stable identifier of the selected edge. */
+  edgeId: string;
+}
+
+/**
+ * An active selection within the workflow graph.
+ *
+ * A `null` or absent selection means workflow-level (no element selected).
+ */
+export type EditorSelection = NodeSelection | EdgeSelection;

--- a/packages/editor-host-client/src/index.ts
+++ b/packages/editor-host-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./contracts/index.js";

--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -13,7 +13,7 @@
 
 - [ ] T004 Implement source parse/serialize service in `packages/editor-core/src/source/`
 - [ ] T005 [P] Implement diagnostics model and event payload types in `packages/editor-core/src/diagnostics/`
-- [ ] T006 [P] Implement host contract surface types in `packages/editor-host-client/src/contracts/`
+- [x] T006 [P] Implement host contract surface types in `packages/editor-host-client/src/contracts/`
 - [ ] T007 Implement monotonic revision tracking in `packages/editor-core/src/state/`
 - [ ] T008 Implement event bridge from core to web component in `packages/editor-web-component/src/events/`
 


### PR DESCRIPTION
## Summary

- Add `packages/editor-host-client/src/contracts/` module with TypeScript interfaces for the full host–editor contract surface
- Define `HostEditorContract` interface covering all five contract methods: `loadWorkflowSource`, `exportWorkflowSource`, `validateWorkflow`, `setSelection`, `getCapabilities`
- Define `EditorEventName` constants and typed payload interfaces for all four events: `workflowChanged`, `editorSelectionChanged`, `editorDiagnosticsChanged`, `editorError`
- Define `CapabilitySnapshot` and `RendererCapabilitySnapshot` types derived from `data-model.md`
- All payloads include `version` (contract SemVer) and `revision` (monotonic counter) fields per contract payload rules
- Export everything from the package `index.ts`; types verified with `tsc --noEmit`
- Mark T006 complete in `specs/001-visual-authoring-mvp/tasks.md`

Closes #22

## Test plan

- [x] `pnpm --filter @sw-editor/editor-host-client build` passes with no TypeScript errors
- [ ] Downstream packages can import types without issue (validated when T012 and T017 are implemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)