### PR TITLE
feat(editor-renderer-react-flow): implement React Flow renderer adapter

### DIFF
--- a/packages/editor-renderer-react-flow/package.json
+++ b/packages/editor-renderer-react-flow/package.json
@@ -11,9 +11,14 @@
     "build": "tsc --noEmit"
   },
   "dependencies": {
-    "@sw-editor/editor-renderer-contract": "workspace:*"
+    "@sw-editor/editor-renderer-contract": "workspace:*",
+    "@xyflow/react": "^12.6.4",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "typescript": "5.9.3"
   }
 }

--- a/packages/editor-renderer-react-flow/src/index.ts
+++ b/packages/editor-renderer-react-flow/src/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @packageDocumentation
+ *
+ * React Flow renderer adapter for the sw-editor visual workflow editor.
+ *
+ * Exports the {@link ReactFlowAdapter} class which implements the shared
+ * {@link RendererAdapter} contract defined in `@sw-editor/editor-renderer-contract`.
+ *
+ * @example
+ * ```ts
+ * import { ReactFlowAdapter } from "@sw-editor/editor-renderer-react-flow";
+ *
+ * const adapter = new ReactFlowAdapter();
+ * adapter.mount(document.getElementById("editor")!, initialGraph);
+ * adapter.events.onSelectionChange(event => console.log(event));
+ * adapter.update(updatedGraph);
+ * adapter.dispose();
+ * ```
+ */
+export { ReactFlowAdapter } from "./react-flow-adapter.js";

--- a/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
+++ b/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
@@ -1,0 +1,413 @@
+/**
+ * React Flow renderer adapter implementing the shared {@link RendererAdapter} contract.
+ *
+ * This module bridges the editor-core renderer contract to the @xyflow/react
+ * library. It mounts a React Flow graph into a provided DOM container, keeps
+ * the rendered graph in sync with {@link WorkflowGraph} updates, bridges
+ * React Flow selection events to the normalised {@link RendererSelectionEvent}
+ * format, and exposes an accurate {@link RendererCapabilitySnapshot}.
+ *
+ * @module
+ */
+import React, { useState, useLayoutEffect } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  ReactFlow,
+  ReactFlowProvider,
+  type Node,
+  type Edge,
+  type OnSelectionChangeParams,
+} from "@xyflow/react";
+import type {
+  RendererAdapter,
+  RendererCapabilitySnapshot,
+  RendererEventBridge,
+  RendererGraphNode,
+  RendererGraphEdge,
+  RendererSelectionEvent,
+  RendererSelectionHandler,
+  WorkflowGraph,
+} from "@sw-editor/editor-renderer-contract";
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/** React Flow node with required position coordinates. */
+type RFNode = Node;
+/** React Flow edge. */
+type RFEdge = Edge;
+
+/**
+ * Imperative handle exposed by {@link WorkflowFlowApp} to the adapter so
+ * that graph state can be updated without re-mounting the React tree.
+ */
+interface FlowController {
+  /**
+   * Replace the current nodes and edges in the rendered React Flow graph.
+   *
+   * @param nodes - The updated array of React Flow nodes.
+   * @param edges - The updated array of React Flow edges.
+   */
+  updateGraph(nodes: RFNode[], edges: RFEdge[]): void;
+}
+
+/** Props for the internal {@link WorkflowFlowApp} component. */
+interface WorkflowFlowAppProps {
+  /** Initial React Flow nodes to display on first render. */
+  initialNodes: RFNode[];
+  /** Initial React Flow edges to display on first render. */
+  initialEdges: RFEdge[];
+  /**
+   * Callback invoked by React Flow whenever the user selection changes.
+   *
+   * @param params - Selected nodes and edges at the time of the event.
+   */
+  onSelectionChange: (params: OnSelectionChangeParams) => void;
+  /**
+   * Called once after initial render with an imperative controller that
+   * the adapter uses to push graph updates into React state.
+   *
+   * @param controller - The imperative controller for this component instance.
+   */
+  onController: (controller: FlowController) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Graph conversion helpers
+// ---------------------------------------------------------------------------
+
+/** Horizontal gap between nodes when arranging in a simple linear layout. */
+const NODE_H_GAP = 200;
+/** Vertical position used for all nodes in the default layout. */
+const NODE_Y = 0;
+
+/**
+ * Derive a simple left-to-right layout position for each node based on its
+ * index in the ordered nodes array.
+ *
+ * The layout is intentionally minimal: React Flow handles interactive
+ * repositioning once the graph is rendered. A more sophisticated auto-layout
+ * can be layered on top in future capability expansions.
+ *
+ * @param index - Zero-based position of the node in the nodes array.
+ * @returns The `{x, y}` coordinates for the node.
+ */
+function nodePosition(index: number): { x: number; y: number } {
+  return { x: index * NODE_H_GAP, y: NODE_Y };
+}
+
+/**
+ * Convert a {@link RendererGraphNode} to a React Flow {@link Node}.
+ *
+ * @param node - The renderer graph node to convert.
+ * @param index - The index of the node in the ordered nodes array, used for
+ *   default layout positioning.
+ * @returns A React Flow node object suitable for passing to `<ReactFlow>`.
+ */
+function toRFNode(node: RendererGraphNode, index: number): RFNode {
+  return {
+    id: node.id,
+    type: node.kind,
+    position: nodePosition(index),
+    data: {
+      ...node.data,
+      kind: node.kind,
+      ...(node.taskReference !== undefined
+        ? { taskReference: node.taskReference }
+        : {}),
+    },
+  };
+}
+
+/**
+ * Convert a {@link RendererGraphEdge} to a React Flow {@link Edge}.
+ *
+ * @param edge - The renderer graph edge to convert.
+ * @returns A React Flow edge object suitable for passing to `<ReactFlow>`.
+ */
+function toRFEdge(edge: RendererGraphEdge): RFEdge {
+  return {
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    ...(edge.label !== undefined ? { label: edge.label } : {}),
+  };
+}
+
+/**
+ * Convert a {@link WorkflowGraph} to separate React Flow nodes and edges arrays.
+ *
+ * @param graph - The workflow graph to convert.
+ * @returns An object containing the converted `nodes` and `edges` arrays.
+ */
+function toRFGraph(graph: WorkflowGraph): {
+  nodes: RFNode[];
+  edges: RFEdge[];
+} {
+  return {
+    nodes: graph.nodes.map((n, i) => toRFNode(n, i)),
+    edges: graph.edges.map((e) => toRFEdge(e)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// React component
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal React component that renders the React Flow canvas.
+ *
+ * The component maintains its own nodes/edges state and exposes an imperative
+ * {@link FlowController} handle via `onController` so that the
+ * {@link ReactFlowAdapter} can push graph updates without re-mounting.
+ *
+ * @param props - Component properties.
+ * @returns A React element containing the React Flow canvas wrapped in a provider.
+ */
+function WorkflowFlowApp(props: WorkflowFlowAppProps): React.ReactElement {
+  const [nodes, setNodes] = useState<RFNode[]>(props.initialNodes);
+  const [edges, setEdges] = useState<RFEdge[]>(props.initialEdges);
+
+  // Expose an imperative controller to the adapter immediately after mount.
+  // Using useLayoutEffect ensures the controller is available before the
+  // browser has painted, which prevents a race between mount() returning and
+  // the first update() call arriving.
+  useLayoutEffect(() => {
+    props.onController({
+      updateGraph(newNodes: RFNode[], newEdges: RFEdge[]): void {
+        setNodes(newNodes);
+        setEdges(newEdges);
+      },
+    });
+    // The dependency array is intentionally empty: we only want to publish the
+    // controller once, after the initial render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return React.createElement(
+    ReactFlowProvider,
+    null,
+    React.createElement(ReactFlow, {
+      nodes,
+      edges,
+      onSelectionChange: props.onSelectionChange,
+      fitView: true,
+      proOptions: { hideAttribution: false },
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Event bridge implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * Implementation of {@link RendererEventBridge} that stores a single
+ * selection-change handler and allows it to be replaced or removed.
+ */
+class ReactFlowEventBridge implements RendererEventBridge {
+  /** The currently registered selection handler, or `undefined` if none. */
+  private selectionHandler: RendererSelectionHandler | undefined;
+
+  /**
+   * Register a callback to receive normalised selection change events.
+   *
+   * Replaces any previously registered handler.
+   *
+   * @param handler - The callback to invoke on selection changes.
+   */
+  onSelectionChange(handler: RendererSelectionHandler): void {
+    this.selectionHandler = handler;
+  }
+
+  /**
+   * Remove the currently registered selection-change handler, if any.
+   */
+  offSelectionChange(): void {
+    this.selectionHandler = undefined;
+  }
+
+  /**
+   * Translate a raw React Flow selection event into a {@link RendererSelectionEvent}
+   * and dispatch it to the registered handler.
+   *
+   * When exactly one node is selected and no edges are selected the event is
+   * {@link RendererNodeSelection}. When exactly one edge is selected and no
+   * nodes are selected the event is {@link RendererEdgeSelection}. All other
+   * combinations (multi-select, empty selection) produce
+   * {@link RendererClearSelection}.
+   *
+   * @param params - The raw selection params from React Flow.
+   */
+  handleRFSelection(params: OnSelectionChangeParams): void {
+    if (this.selectionHandler === undefined) {
+      return;
+    }
+
+    const { nodes: selectedNodes, edges: selectedEdges } = params;
+
+    let event: RendererSelectionEvent;
+
+    if (selectedNodes.length === 1 && selectedEdges.length === 0) {
+      const node = selectedNodes[0];
+      if (node === undefined) {
+        event = { kind: "none" };
+      } else {
+        event = { kind: "node", nodeId: node.id };
+      }
+    } else if (selectedEdges.length === 1 && selectedNodes.length === 0) {
+      const edge = selectedEdges[0];
+      if (edge === undefined) {
+        event = { kind: "none" };
+      } else {
+        event = { kind: "edge", edgeId: edge.id };
+      }
+    } else {
+      event = { kind: "none" };
+    }
+
+    this.selectionHandler(event);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adapter implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * React Flow renderer adapter implementing the shared {@link RendererAdapter}
+ * contract.
+ *
+ * Lifecycle:
+ * 1. Construct the adapter — sets up capability snapshot and event bridge.
+ * 2. Call {@link mount} with a container element and initial graph — mounts a
+ *    React root and renders the React Flow canvas.
+ * 3. Call {@link update} with new graph data — pushes the update into React
+ *    state without re-mounting.
+ * 4. Call {@link dispose} — unmounts the React root and releases resources.
+ *
+ * The adapter must not initiate any network calls during its lifecycle.
+ *
+ * @example
+ * ```ts
+ * const adapter = new ReactFlowAdapter();
+ * adapter.mount(containerElement, initialGraph);
+ * adapter.events.onSelectionChange(event => console.log(event));
+ * adapter.update(updatedGraph);
+ * adapter.dispose();
+ * ```
+ */
+export class ReactFlowAdapter implements RendererAdapter {
+  /** @inheritdoc */
+  readonly rendererId = "react-flow" as const;
+
+  /** @inheritdoc */
+  readonly capabilities: RendererCapabilitySnapshot = {
+    rendererId: "react-flow",
+    rendererVersion: "12.x",
+    supportsNodeRendererPlugins: true,
+    supportsNestedInlineProjection: false,
+    supportsRouteOverlayProjection: false,
+    knownLimits: [
+      "Nested inline sub-workflow projection is not supported in this release.",
+      "Route/transition overlay annotations are not supported in this release.",
+    ],
+  };
+
+  /** @inheritdoc */
+  readonly events: ReactFlowEventBridge = new ReactFlowEventBridge();
+
+  /** The React DOM root created during {@link mount}; `null` before mount and after dispose. */
+  private root: Root | null = null;
+
+  /** Imperative controller used to push graph updates into React state without re-mounting. */
+  private controller: FlowController | null = null;
+
+  /** Whether {@link dispose} has been called. */
+  private disposed = false;
+
+  /**
+   * Attach the React Flow renderer to `container` and render the initial graph.
+   *
+   * Creates a React DOM root and mounts the internal {@link WorkflowFlowApp}
+   * component. The adapter registers itself as the imperative controller so
+   * that subsequent {@link update} calls can push data into React state.
+   *
+   * Must be called exactly once before {@link update} or {@link dispose}.
+   *
+   * @param container - The DOM element to render into. The adapter takes
+   *   ownership of this element's subtree while mounted.
+   * @param graph - The initial workflow graph to display.
+   * @throws {Error} If called after {@link dispose}.
+   */
+  mount(container: HTMLElement, graph: WorkflowGraph): void {
+    if (this.disposed) {
+      throw new Error("ReactFlowAdapter: mount() called after dispose()");
+    }
+
+    const { nodes, edges } = toRFGraph(graph);
+    this.root = createRoot(container);
+
+    const bridge = this.events;
+
+    this.root.render(
+      React.createElement(WorkflowFlowApp, {
+        initialNodes: nodes,
+        initialEdges: edges,
+        onSelectionChange: (params: OnSelectionChangeParams) => {
+          bridge.handleRFSelection(params);
+        },
+        onController: (controller: FlowController) => {
+          this.controller = controller;
+        },
+      })
+    );
+  }
+
+  /**
+   * Re-render the React Flow graph with updated data.
+   *
+   * Pushes new nodes and edges into the React component state via the
+   * imperative controller. React Flow applies the minimal structural changes
+   * needed to reflect the new graph; a full remount is not performed.
+   *
+   * Must be called after a successful {@link mount}.
+   *
+   * @param graph - The updated workflow graph to display.
+   * @throws {Error} If called before {@link mount} or after {@link dispose}.
+   */
+  update(graph: WorkflowGraph): void {
+    if (this.disposed) {
+      throw new Error("ReactFlowAdapter: update() called after dispose()");
+    }
+    if (this.controller === null) {
+      throw new Error(
+        "ReactFlowAdapter: update() called before mount() completed"
+      );
+    }
+
+    const { nodes, edges } = toRFGraph(graph);
+    this.controller.updateGraph(nodes, edges);
+  }
+
+  /**
+   * Release all renderer resources and detach from the DOM.
+   *
+   * Unmounts the React root and clears internal references. After `dispose`
+   * the adapter instance must not be reused; calling {@link update} or
+   * {@link dispose} again is a programming error.
+   */
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.events.offSelectionChange();
+    this.controller = null;
+    if (this.root !== null) {
+      this.root.unmount();
+      this.root = null;
+    }
+  }
+}

--- a/packages/editor-renderer-react-flow/tsconfig.json
+++ b/packages/editor-renderer-react-flow/tsconfig.json
@@ -3,7 +3,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "lib": ["ES2022", "DOM"],
+    "jsx": "react"
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,22 @@ importers:
       '@sw-editor/editor-renderer-contract':
         specifier: workspace:*
         version: link:../editor-renderer-contract
+      '@xyflow/react':
+        specifier: ^12.6.4
+        version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.1.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@types/react':
+        specifier: ^19.1.8
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.6
+        version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -457,11 +472,37 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -492,6 +533,15 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
+  '@xyflow/react@12.10.1':
+    resolution: {integrity: sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.75':
+    resolution: {integrity: sha512-iXs+AGFLi8w/VlAoc/iSxk+CxfT6o64Uw/k0CKASOPqjqz6E0rb5jFZgJtXGZCpfQI6OQpu5EnumP5fGxQheaQ==}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -513,6 +563,50 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -596,6 +690,15 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
@@ -604,6 +707,9 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -637,6 +743,11 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
@@ -716,6 +827,21 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -926,9 +1052,38 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -969,6 +1124,29 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
+  '@xyflow/react@12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@xyflow/system': 0.0.75
+      classcat: 5.0.5
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      zustand: 4.5.7(@types/react@19.2.14)(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.75':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -985,6 +1163,46 @@ snapshots:
   assertion-error@2.0.1: {}
 
   chai@6.2.2: {}
+
+  classcat@5.0.5: {}
+
+  csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   es-module-lexer@1.7.0: {}
 
@@ -1071,6 +1289,13 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react@19.2.4: {}
+
   require-from-string@2.0.2: {}
 
   rollup@4.59.0:
@@ -1104,6 +1329,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  scheduler@0.27.0: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1124,6 +1351,10 @@ snapshots:
   tinyrainbow@3.0.3: {}
 
   typescript@5.9.3: {}
+
+  use-sync-external-store@1.6.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   vite@7.3.1:
     dependencies:
@@ -1175,3 +1406,10 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4

--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -21,7 +21,7 @@
 
 - [ ] T009 Define renderer abstraction contract (`mount`, `update`, `dispose`, selection/event bridge) in `packages/editor-renderer-contract/src/renderer-adapter.ts`
 - [ ] T010 [P] Implement `rete-lit` adapter against renderer contract in `packages/editor-renderer-rete-lit/src/rete-lit-adapter.ts`
-- [ ] T011 [P] Implement `react-flow` adapter against renderer contract in `packages/editor-renderer-react-flow/src/react-flow-adapter.ts`
+- [x] T011 [P] Implement `react-flow` adapter against renderer contract in `packages/editor-renderer-react-flow/src/react-flow-adapter.ts`
 - [ ] T012 Wire bundle-level renderer selection and capability exposure in `packages/editor-host-client/src/contracts/capabilities.ts`
 
 ## Phase 3: User Story 1 - Create A Valid Workflow Visually (Priority: P1)


### PR DESCRIPTION
## Summary

- Implements `ReactFlowAdapter` class satisfying the `RendererAdapter` contract defined in `@sw-editor/editor-renderer-contract`
- `mount()` creates a React DOM root via `createRoot` and renders `WorkflowFlowApp` (internal component) into the provided container
- `update()` pushes graph changes into React state via an imperative `FlowController` handle exposed by the component after initial render
- `dispose()` unmounts the React root and releases all resources; adapter instance cannot be reused after dispose
- Selection bridge converts React Flow's `onSelectionChange` events to the normalised `RendererSelectionEvent` (node / edge / none) expected by editor-core
- `RendererCapabilitySnapshot` accurately reflects react-flow capabilities: `supportsNodeRendererPlugins: true`, nested/route overlay projections disabled with documented limits
- Adds `@xyflow/react`, `react`, `react-dom` as runtime dependencies; `@types/react`, `@types/react-dom` as dev deps
- Updates package `tsconfig.json` to include `DOM` lib and `jsx: react` for React element creation via `React.createElement`
- Marks T011 complete in `specs/001-visual-authoring-mvp/tasks.md`

## Test plan

- [x] `pnpm build` in `packages/editor-renderer-react-flow` passes with `tsc --noEmit` (zero type errors)
- [ ] Manually verify React Flow renders into a container element with `mount()` / `update()` / `dispose()` lifecycle
- [ ] Selection events correctly produce `RendererNodeSelection`, `RendererEdgeSelection`, or `RendererClearSelection`

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)