### PR TITLE
feat(editor-host-client): wire bundle-level renderer selection (#28)

### DIFF
--- a/packages/editor-host-client/package.json
+++ b/packages/editor-host-client/package.json
@@ -5,14 +5,18 @@
   "description": "Thin host client providing the host-editor contract surface and export utilities",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./rete-lit": "./src/rete-lit.ts",
+    "./react-flow": "./src/react-flow.ts"
   },
   "scripts": {
     "build": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {
-    "@sw-editor/editor-core": "workspace:*"
+    "@sw-editor/editor-core": "workspace:*",
+    "@sw-editor/editor-renderer-rete-lit": "workspace:*",
+    "@sw-editor/editor-renderer-react-flow": "workspace:*"
   },
   "devDependencies": {
     "typescript": "5.9.3",

--- a/packages/editor-host-client/src/contracts/capabilities.ts
+++ b/packages/editor-host-client/src/contracts/capabilities.ts
@@ -53,3 +53,64 @@ export interface CapabilitySnapshot {
   /** Renderer-specific capability details. */
   rendererCapabilities: RendererCapabilitySnapshot;
 }
+
+// ---------------------------------------------------------------------------
+// Contract-level metadata constants
+// ---------------------------------------------------------------------------
+
+/**
+ * SemVer string of the host–editor contract implemented by this package.
+ *
+ * Increment the major version when a backward-incompatible API change is made.
+ * Hosts should verify that the major component matches their expectation before
+ * issuing further API calls.
+ */
+export const CONTRACT_VERSION = "0.1.0" as const;
+
+/**
+ * Serverless Workflow specification version that this editor primarily targets.
+ *
+ * Corresponds to the latest specification version whose full feature set is
+ * supported by the editor's parse, validate, and project pipeline.
+ */
+export const TARGET_VERSION = "1.0" as const;
+
+/**
+ * All Serverless Workflow specification versions that this editor can parse
+ * and validate, including {@link TARGET_VERSION}.
+ *
+ * Hosts may inspect this list to determine whether a document of a given
+ * specification version can be opened without degraded behavior.
+ */
+export const SUPPORTED_VERSIONS: readonly string[] = ["0.8", "0.9", "1.0"] as const;
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct a {@link CapabilitySnapshot} from a renderer's capability snapshot.
+ *
+ * Combines the static contract-level metadata ({@link CONTRACT_VERSION},
+ * {@link TARGET_VERSION}, {@link SUPPORTED_VERSIONS}) with the renderer-specific
+ * details supplied by the active renderer adapter.
+ *
+ * Each renderer bundle entry calls this function once at module evaluation time
+ * and re-exports the frozen result via its `getCapabilities` export. This
+ * ensures that renderer selection is fixed at build time and that no runtime
+ * switching is possible.
+ *
+ * @param rendererCapabilities - The capability snapshot from the active renderer adapter.
+ * @returns A fully-populated {@link CapabilitySnapshot} for the current bundle.
+ */
+export function createCapabilitySnapshot(
+  rendererCapabilities: RendererCapabilitySnapshot,
+): CapabilitySnapshot {
+  return {
+    contractVersion: CONTRACT_VERSION,
+    targetVersion: TARGET_VERSION,
+    supportedVersions: [...SUPPORTED_VERSIONS],
+    rendererId: rendererCapabilities.rendererId,
+    rendererCapabilities,
+  };
+}

--- a/packages/editor-host-client/src/react-flow.ts
+++ b/packages/editor-host-client/src/react-flow.ts
@@ -1,0 +1,54 @@
+/**
+ * React-flow bundle entry for `@sw-editor/editor-host-client`.
+ *
+ * Importing this module wires the `react-flow` renderer backend into the
+ * host–editor contract surface. The renderer is selected at build time by
+ * choosing this entry point; no runtime switching is possible once an entry
+ * point has been imported.
+ *
+ * @example
+ * ```ts
+ * import { getCapabilities } from "@sw-editor/editor-host-client/react-flow";
+ *
+ * const snapshot = getCapabilities();
+ * console.log(snapshot.rendererId); // "react-flow"
+ * ```
+ *
+ * @module
+ */
+
+import { ReactFlowAdapter } from "@sw-editor/editor-renderer-react-flow";
+import {
+  createCapabilitySnapshot,
+  type CapabilitySnapshot,
+} from "./contracts/capabilities.js";
+
+// Instantiate a transient adapter solely to read its static capability snapshot.
+// The adapter is not mounted and will not render anything; `capabilities` is a
+// module-level constant on the adapter class.
+const _adapter = new ReactFlowAdapter();
+
+/**
+ * The capability snapshot for the `react-flow` renderer bundle, computed once
+ * at module evaluation time and frozen for the lifetime of the process.
+ */
+const _snapshot: CapabilitySnapshot = createCapabilitySnapshot(
+  _adapter.capabilities,
+);
+
+/**
+ * Return the capability snapshot for the active `react-flow` editor bundle.
+ *
+ * Hosts should call this function once after mounting the editor to verify
+ * contract and spec version compatibility before issuing further API calls.
+ * The returned snapshot is identical on every call; it is computed at module
+ * load time and cannot change at runtime.
+ *
+ * @returns The {@link CapabilitySnapshot} for this react-flow bundle.
+ */
+export function getCapabilities(): CapabilitySnapshot {
+  return _snapshot;
+}
+
+export type { CapabilitySnapshot };
+export type { RendererCapabilitySnapshot } from "./contracts/capabilities.js";

--- a/packages/editor-host-client/src/rete-lit.ts
+++ b/packages/editor-host-client/src/rete-lit.ts
@@ -1,0 +1,54 @@
+/**
+ * Rete-lit bundle entry for `@sw-editor/editor-host-client`.
+ *
+ * Importing this module wires the `rete-lit` renderer backend into the
+ * host–editor contract surface. The renderer is selected at build time by
+ * choosing this entry point; no runtime switching is possible once an entry
+ * point has been imported.
+ *
+ * @example
+ * ```ts
+ * import { getCapabilities } from "@sw-editor/editor-host-client/rete-lit";
+ *
+ * const snapshot = getCapabilities();
+ * console.log(snapshot.rendererId); // "rete-lit"
+ * ```
+ *
+ * @module
+ */
+
+import { ReteLitAdapter } from "@sw-editor/editor-renderer-rete-lit";
+import {
+  createCapabilitySnapshot,
+  type CapabilitySnapshot,
+} from "./contracts/capabilities.js";
+
+// Instantiate a transient adapter solely to read its static capability snapshot.
+// The adapter is not mounted and will not render anything; `capabilities` is a
+// module-level constant on the adapter class.
+const _adapter = new ReteLitAdapter();
+
+/**
+ * The capability snapshot for the `rete-lit` renderer bundle, computed once
+ * at module evaluation time and frozen for the lifetime of the process.
+ */
+const _snapshot: CapabilitySnapshot = createCapabilitySnapshot(
+  _adapter.capabilities,
+);
+
+/**
+ * Return the capability snapshot for the active `rete-lit` editor bundle.
+ *
+ * Hosts should call this function once after mounting the editor to verify
+ * contract and spec version compatibility before issuing further API calls.
+ * The returned snapshot is identical on every call; it is computed at module
+ * load time and cannot change at runtime.
+ *
+ * @returns The {@link CapabilitySnapshot} for this rete-lit bundle.
+ */
+export function getCapabilities(): CapabilitySnapshot {
+  return _snapshot;
+}
+
+export type { CapabilitySnapshot };
+export type { RendererCapabilitySnapshot } from "./contracts/capabilities.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,12 @@ importers:
       '@sw-editor/editor-core':
         specifier: workspace:*
         version: link:../editor-core
+      '@sw-editor/editor-renderer-react-flow':
+        specifier: workspace:*
+        version: link:../editor-renderer-react-flow
+      '@sw-editor/editor-renderer-rete-lit':
+        specifier: workspace:*
+        version: link:../editor-renderer-rete-lit
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -80,9 +86,27 @@ importers:
 
   packages/editor-renderer-rete-lit:
     dependencies:
+      '@retejs/lit-plugin':
+        specifier: ^2.0.0
+        version: 2.0.7(lit@3.3.2)(rete-area-plugin@2.1.5(rete@2.0.6))(rete-render-utils@2.0.3(rete-area-plugin@2.1.5(rete@2.0.6))(rete@2.0.6))(rete@2.0.6)
       '@sw-editor/editor-renderer-contract':
         specifier: workspace:*
         version: link:../editor-renderer-contract
+      lit:
+        specifier: ^3.0.0
+        version: 3.3.2
+      rete:
+        specifier: ^2.0.0
+        version: 2.0.6
+      rete-area-plugin:
+        specifier: ^2.0.0
+        version: 2.1.5(rete@2.0.6)
+      rete-connection-plugin:
+        specifier: ^2.0.0
+        version: 2.0.5(rete-area-plugin@2.1.5(rete@2.0.6))(rete@2.0.6)
+      rete-render-utils:
+        specifier: ^2.0.0
+        version: 2.0.3(rete-area-plugin@2.1.5(rete@2.0.6))(rete@2.0.6)
     devDependencies:
       typescript:
         specifier: 5.9.3
@@ -105,6 +129,10 @@ importers:
         version: 4.0.18
 
 packages:
+
+  '@babel/runtime@7.28.6':
+    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+    engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@2.4.5':
     resolution: {integrity: sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ==}
@@ -322,10 +350,24 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@lit-labs/ssr-dom-shim@1.5.1':
+    resolution: {integrity: sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==}
+
+  '@lit/reactive-element@2.1.2':
+    resolution: {integrity: sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==}
+
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@retejs/lit-plugin@2.0.7':
+    resolution: {integrity: sha512-jnrZ10lwmoxCi9eqViblAi7D8VxMrsGiS/tkn55YOR19xoGxF2Z9rzmdg0RfR8qsNHubHsQDjDFmGbL8tbDmbA==}
+    peerDependencies:
+      lit: ^3.0.0
+      rete: ^2.0.0
+      rete-area-plugin: ^2.0.0
+      rete-render-utils: ^2.0.0
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -507,6 +549,9 @@ packages:
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
@@ -658,6 +703,15 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
+  lit-element@4.2.2:
+    resolution: {integrity: sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==}
+
+  lit-html@3.3.2:
+    resolution: {integrity: sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==}
+
+  lit@3.3.2:
+    resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -705,6 +759,26 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  rete-area-plugin@2.1.5:
+    resolution: {integrity: sha512-iquEvwkQlcsO4cmgM3Z37TG0AWaE536dfA+lCJAze5YJzVx4RBaViUCqdB4dUA/utSytpBCkiDC4D3ztM9akGQ==}
+    peerDependencies:
+      rete: ^2.0.0
+
+  rete-connection-plugin@2.0.5:
+    resolution: {integrity: sha512-KFtlOyEJRc0y9STVgo2T+t+j9u5fxiTxbyzPbMCm0uqncb3b8d2ABDIzvWoNo5zQAh2Oz/OvlUovupbzrGzpSg==}
+    peerDependencies:
+      rete: ^2.0.1
+      rete-area-plugin: ^2.0.0
+
+  rete-render-utils@2.0.3:
+    resolution: {integrity: sha512-Oz4W2PNayHocRvlzadb5BCNf+tDzJ8RhTwB3ucBPCdCLKZ974wWDiTSCRfA287L2hmHVzRfBdyAwC03K9eP+4g==}
+    peerDependencies:
+      rete: ^2.0.0
+      rete-area-plugin: ^2.0.0
+
+  rete@2.0.6:
+    resolution: {integrity: sha512-kPmlKCGFES2VWtY7Y7SCB8ZeXRMsgX5deza9cu4OwmfM/ZUimd461kC3hRyccoyVxE4POlHUx0gg2jcGfusHFg==}
 
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
@@ -848,6 +922,8 @@ packages:
 
 snapshots:
 
+  '@babel/runtime@7.28.6': {}
+
   '@biomejs/biome@2.4.5':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.4.5
@@ -963,9 +1039,22 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@lit-labs/ssr-dom-shim@1.5.1': {}
+
+  '@lit/reactive-element@2.1.2':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@retejs/lit-plugin@2.0.7(lit@3.3.2)(rete-area-plugin@2.1.5(rete@2.0.6))(rete-render-utils@2.0.3(rete-area-plugin@2.1.5(rete@2.0.6))(rete@2.0.6))(rete@2.0.6)':
+    dependencies:
+      lit: 3.3.2
+      rete: 2.0.6
+      rete-area-plugin: 2.1.5(rete@2.0.6)
+      rete-render-utils: 2.0.3(rete-area-plugin@2.1.5(rete@2.0.6))(rete@2.0.6)
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -1087,6 +1176,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7': {}
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -1264,6 +1355,22 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
+  lit-element@4.2.2:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.5.1
+      '@lit/reactive-element': 2.1.2
+      lit-html: 3.3.2
+
+  lit-html@3.3.2:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit@3.3.2:
+    dependencies:
+      '@lit/reactive-element': 2.1.2
+      lit-element: 4.2.2
+      lit-html: 3.3.2
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -1300,6 +1407,27 @@ snapshots:
   react@19.2.4: {}
 
   require-from-string@2.0.2: {}
+
+  rete-area-plugin@2.1.5(rete@2.0.6):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      rete: 2.0.6
+
+  rete-connection-plugin@2.0.5(rete-area-plugin@2.1.5(rete@2.0.6))(rete@2.0.6):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      rete: 2.0.6
+      rete-area-plugin: 2.1.5(rete@2.0.6)
+
+  rete-render-utils@2.0.3(rete-area-plugin@2.1.5(rete@2.0.6))(rete@2.0.6):
+    dependencies:
+      '@babel/runtime': 7.28.6
+      rete: 2.0.6
+      rete-area-plugin: 2.1.5(rete@2.0.6)
+
+  rete@2.0.6:
+    dependencies:
+      '@babel/runtime': 7.28.6
 
   rollup@4.59.0:
     dependencies:

--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -22,7 +22,7 @@
 - [x] T009 Define renderer abstraction contract (`mount`, `update`, `dispose`, selection/event bridge) in `packages/editor-renderer-contract/src/renderer-adapter.ts`
 - [x] T010 [P] Implement `rete-lit` adapter against renderer contract in `packages/editor-renderer-rete-lit/src/rete-lit-adapter.ts`
 - [x] T011 [P] Implement `react-flow` adapter against renderer contract in `packages/editor-renderer-react-flow/src/react-flow-adapter.ts`
-- [ ] T012 Wire bundle-level renderer selection and capability exposure in `packages/editor-host-client/src/contracts/capabilities.ts`
+- [x] T012 Wire bundle-level renderer selection and capability exposure in `packages/editor-host-client/src/contracts/capabilities.ts`
 
 ## Phase 3: User Story 1 - Create A Valid Workflow Visually (Priority: P1)
 


### PR DESCRIPTION
## Summary

- Added `CONTRACT_VERSION`, `TARGET_VERSION`, `SUPPORTED_VERSIONS` constants and `createCapabilitySnapshot()` factory to `capabilities.ts`
- Created `src/rete-lit.ts` bundle entry: imports `ReteLitAdapter`, derives the capability snapshot at module load time, exports `getCapabilities(): CapabilitySnapshot`
- Created `src/react-flow.ts` bundle entry: same pattern for `ReactFlowAdapter`
- Updated `package.json` with `./rete-lit` and `./react-flow` exports and workspace dependencies on both renderer packages

## Design

Build-time renderer selection is enforced by having separate named entry points:
- `import { getCapabilities } from "@sw-editor/editor-host-client/rete-lit"` → rete-lit capabilities
- `import { getCapabilities } from "@sw-editor/editor-host-client/react-flow"` → react-flow capabilities

Each entry instantiates its renderer adapter once at module evaluation time to read its static `capabilities` property, then discards the instance. No runtime switching API is exposed.

## Test plan

- [ ] Import `@sw-editor/editor-host-client/rete-lit` and verify `getCapabilities().rendererId === "rete-lit"`
- [ ] Import `@sw-editor/editor-host-client/react-flow` and verify `getCapabilities().rendererId === "react-flow"`
- [ ] Verify `CapabilitySnapshot` contains `contractVersion`, `targetVersion`, `supportedVersions`, `rendererId`, and `rendererCapabilities`
- [ ] Confirm no `switchRenderer()` or equivalent runtime-switching API exists

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)