### PR TITLE
feat(editor-core): add start/end synthetic node bootstrap

### DIFF
--- a/packages/editor-core/src/graph/bootstrap.ts
+++ b/packages/editor-core/src/graph/bootstrap.ts
@@ -1,0 +1,66 @@
+import type { GraphEdge, GraphNode, WorkflowGraph } from "./types.js";
+
+/**
+ * Stable ID reserved for the synthetic start boundary node.
+ *
+ * This ID must not be used for any task node and will remain constant across
+ * the lifetime of an editor session.
+ */
+export const START_NODE_ID = "__start__";
+
+/**
+ * Stable ID reserved for the synthetic end boundary node.
+ *
+ * This ID must not be used for any task node and will remain constant across
+ * the lifetime of an editor session.
+ */
+export const END_NODE_ID = "__end__";
+
+/**
+ * Stable ID reserved for the initial edge connecting the start node to the
+ * end node in a freshly bootstrapped graph.
+ */
+export const INITIAL_EDGE_ID = "__start__->__end__";
+
+/**
+ * Creates the initial {@link WorkflowGraph} for a blank workflow.
+ *
+ * @remarks
+ * The returned graph satisfies the data-model rule that a new graph must start
+ * with synthetic start and end boundary nodes connected by an edge:
+ *
+ * ```
+ * [__start__] ──► [__end__]
+ * ```
+ *
+ * - Both nodes have `kind` set to the appropriate synthetic boundary kind
+ *   (`"start"` and `"end"`).
+ * - Node and edge IDs are stable constants defined by {@link START_NODE_ID},
+ *   {@link END_NODE_ID}, and {@link INITIAL_EDGE_ID}.
+ * - The returned graph object is a fresh value; callers may mutate it without
+ *   affecting subsequent calls.
+ *
+ * @returns A {@link WorkflowGraph} containing exactly 2 nodes and 1 edge.
+ */
+export function bootstrapWorkflowGraph(): WorkflowGraph {
+  const startNode: GraphNode = {
+    id: START_NODE_ID,
+    kind: "start",
+  };
+
+  const endNode: GraphNode = {
+    id: END_NODE_ID,
+    kind: "end",
+  };
+
+  const initialEdge: GraphEdge = {
+    id: INITIAL_EDGE_ID,
+    source: START_NODE_ID,
+    target: END_NODE_ID,
+  };
+
+  return {
+    nodes: [startNode, endNode],
+    edges: [initialEdge],
+  };
+}

--- a/packages/editor-core/src/graph/index.ts
+++ b/packages/editor-core/src/graph/index.ts
@@ -1,0 +1,7 @@
+export type { GraphEdge, GraphNode, GraphNodeKind, WorkflowGraph } from "./types.js";
+export {
+  END_NODE_ID,
+  INITIAL_EDGE_ID,
+  START_NODE_ID,
+  bootstrapWorkflowGraph,
+} from "./bootstrap.js";

--- a/packages/editor-core/src/graph/types.ts
+++ b/packages/editor-core/src/graph/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Discriminated kind of a graph node.
+ *
+ * - `"start"` and `"end"` are synthetic boundary nodes automatically inserted
+ *   when a new workflow graph is bootstrapped.
+ * - `"task"` represents a real workflow task step.
+ */
+export type GraphNodeKind = "start" | "end" | "task";
+
+/**
+ * A single node in the workflow graph.
+ *
+ * @remarks
+ * `id` is stable across non-destructive edits. Synthetic boundary nodes use
+ * the reserved IDs `"__start__"` and `"__end__"`.
+ */
+export interface GraphNode {
+  /** Stable unique identifier for this node within the graph. */
+  id: string;
+  /** Discriminated kind describing the role of this node. */
+  kind: GraphNodeKind;
+  /**
+   * Reference to the workflow task definition for `"task"` kind nodes.
+   * Absent for synthetic boundary nodes.
+   */
+  taskReference?: string;
+}
+
+/**
+ * A directed edge connecting two nodes in the workflow graph.
+ *
+ * @remarks
+ * `source` and `target` must each reference the `id` of an existing
+ * {@link GraphNode} in the same {@link WorkflowGraph}.
+ */
+export interface GraphEdge {
+  /** Stable unique identifier for this edge within the graph. */
+  id: string;
+  /** `id` of the source node. */
+  source: string;
+  /** `id` of the target node. */
+  target: string;
+}
+
+/**
+ * The complete in-memory graph representation of a workflow.
+ *
+ * @remarks
+ * - A new graph must always contain at least the synthetic start and end nodes
+ *   connected by an edge (see {@link bootstrapWorkflowGraph}).
+ * - Insert operations must preserve graph connectivity.
+ */
+export interface WorkflowGraph {
+  /** Ordered list of graph nodes. */
+  nodes: GraphNode[];
+  /** Ordered list of directed edges between nodes. */
+  edges: GraphEdge[];
+}

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -17,4 +17,5 @@ export type {
 export { parseWorkflowSource, serializeWorkflow } from "./source/index.js";
 
 export * from "./diagnostics/index.js";
+export * from "./graph/index.js";
 export * from "./state/index.js";

--- a/packages/editor-core/tests/graph/bootstrap.test.ts
+++ b/packages/editor-core/tests/graph/bootstrap.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  END_NODE_ID,
+  INITIAL_EDGE_ID,
+  START_NODE_ID,
+  bootstrapWorkflowGraph,
+} from "../../src/graph/index.js";
+import type { WorkflowGraph } from "../../src/graph/index.js";
+
+describe("bootstrapWorkflowGraph", () => {
+  it("returns a graph with exactly 2 nodes and 1 edge", () => {
+    const graph: WorkflowGraph = bootstrapWorkflowGraph();
+    expect(graph.nodes).toHaveLength(2);
+    expect(graph.edges).toHaveLength(1);
+  });
+
+  it("start node has kind 'start' and stable ID", () => {
+    const graph = bootstrapWorkflowGraph();
+    const start = graph.nodes.find((n) => n.id === START_NODE_ID);
+    expect(start).toBeDefined();
+    expect(start?.kind).toBe("start");
+  });
+
+  it("end node has kind 'end' and stable ID", () => {
+    const graph = bootstrapWorkflowGraph();
+    const end = graph.nodes.find((n) => n.id === END_NODE_ID);
+    expect(end).toBeDefined();
+    expect(end?.kind).toBe("end");
+  });
+
+  it("initial edge connects start to end", () => {
+    const graph = bootstrapWorkflowGraph();
+    const edge = graph.edges[0];
+    expect(edge?.id).toBe(INITIAL_EDGE_ID);
+    expect(edge?.source).toBe(START_NODE_ID);
+    expect(edge?.target).toBe(END_NODE_ID);
+  });
+
+  it("synthetic boundary nodes have no taskReference", () => {
+    const graph = bootstrapWorkflowGraph();
+    for (const node of graph.nodes) {
+      expect(node.taskReference).toBeUndefined();
+    }
+  });
+
+  it("returns a fresh graph object on each call", () => {
+    const a = bootstrapWorkflowGraph();
+    const b = bootstrapWorkflowGraph();
+    expect(a).not.toBe(b);
+    expect(a.nodes).not.toBe(b.nodes);
+    expect(a.edges).not.toBe(b.edges);
+  });
+
+  it("mutating the returned graph does not affect subsequent calls", () => {
+    const a = bootstrapWorkflowGraph();
+    a.nodes.push({ id: "extra", kind: "task" });
+    const b = bootstrapWorkflowGraph();
+    expect(b.nodes).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `GraphNodeKind`, `GraphNode`, `GraphEdge`, and `WorkflowGraph` types to `packages/editor-core/src/graph/types.ts`
- Implement `bootstrapWorkflowGraph()` in `packages/editor-core/src/graph/bootstrap.ts` that creates a graph with exactly 2 synthetic boundary nodes (`__start__` / `__end__`) connected by one edge
- Export the new graph sub-module from the editor-core public API
- 7 unit tests covering node count, boundary kinds, stable IDs, edge wiring, and object isolation

## Test plan

- [x] `bootstrapWorkflowGraph` returns exactly 2 nodes and 1 edge
- [x] Start node has `kind: "start"` and stable ID `__start__`
- [x] End node has `kind: "end"` and stable ID `__end__`
- [x] Initial edge connects start → end
- [x] Synthetic nodes have no `taskReference`
- [x] Each call returns independent graph objects (no shared references)
- [x] All 46 editor-core tests pass

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)