### PR TITLE
feat(editor-core): add insertTask command for edge-split node insertion

### DIFF
--- a/packages/editor-core/src/commands/index.ts
+++ b/packages/editor-core/src/commands/index.ts
@@ -1,0 +1,2 @@
+export type { InsertTaskOptions, InsertTaskResult } from "./insert-task.js";
+export { insertTask } from "./insert-task.js";

--- a/packages/editor-core/src/commands/insert-task.ts
+++ b/packages/editor-core/src/commands/insert-task.ts
@@ -1,0 +1,131 @@
+import type { GraphEdge, GraphNode, WorkflowGraph } from "../graph/types.js";
+import type { RevisionCounter } from "../state/revision.js";
+import type { Revision } from "../state/types.js";
+
+/**
+ * Options for the {@link insertTask} command.
+ */
+export interface InsertTaskOptions {
+  /**
+   * ID of the edge to split when inserting the new task node.
+   *
+   * The edge is replaced by two new edges:
+   * `edge.source → newNode` and `newNode → edge.target`.
+   */
+  edgeId: string;
+
+  /**
+   * Optional reference to the workflow task definition associated with the
+   * new node. Stored as {@link GraphNode.taskReference}.
+   */
+  taskReference?: string;
+}
+
+/**
+ * Result returned by a successful {@link insertTask} invocation.
+ */
+export interface InsertTaskResult {
+  /**
+   * Updated workflow graph containing the new task node and re-wired edges.
+   * This is always a fresh object; the original graph passed to `insertTask`
+   * is not mutated.
+   */
+  graph: WorkflowGraph;
+
+  /**
+   * Stable ID assigned to the newly created task node.
+   */
+  nodeId: string;
+
+  /**
+   * Revision number after the insertion. Matches
+   * `counter.currentRevision` immediately after the call.
+   */
+  revision: Revision;
+}
+
+/**
+ * Inserts a new task node into the workflow graph by splitting an existing edge.
+ *
+ * @remarks
+ * Given an edge `source → target`, the command:
+ * 1. Removes the original edge.
+ * 2. Creates a new `"task"` node with a unique stable ID.
+ * 3. Adds edge `source → newNode`.
+ * 4. Adds edge `newNode → target`.
+ * 5. Increments the revision counter.
+ *
+ * The input `graph` is never mutated; a new {@link WorkflowGraph} object is
+ * always returned.
+ *
+ * @param graph - The current workflow graph.
+ * @param counter - The editor revision counter, incremented on success.
+ * @param options - Insertion options including the target edge ID.
+ * @returns An {@link InsertTaskResult} with the updated graph, new node ID,
+ *   and incremented revision.
+ * @throws {Error} If no edge with the given `edgeId` exists in `graph`.
+ */
+export function insertTask(
+  graph: WorkflowGraph,
+  counter: RevisionCounter,
+  options: InsertTaskOptions
+): InsertTaskResult {
+  const { edgeId, taskReference } = options;
+
+  const targetEdge = graph.edges.find((e) => e.id === edgeId);
+  if (!targetEdge) {
+    throw new Error(
+      `insertTask: edge "${edgeId}" not found in graph. Cannot insert task.`
+    );
+  }
+
+  const nodeId = generateNodeId();
+
+  const newNode: GraphNode = {
+    id: nodeId,
+    kind: "task",
+    ...(taskReference !== undefined ? { taskReference } : {}),
+  };
+
+  const edgeToSource: GraphEdge = {
+    id: `${targetEdge.source}->${nodeId}`,
+    source: targetEdge.source,
+    target: nodeId,
+  };
+
+  const edgeToTarget: GraphEdge = {
+    id: `${nodeId}->${targetEdge.target}`,
+    source: nodeId,
+    target: targetEdge.target,
+  };
+
+  const updatedGraph: WorkflowGraph = {
+    nodes: [...graph.nodes, newNode],
+    edges: [
+      ...graph.edges.filter((e) => e.id !== edgeId),
+      edgeToSource,
+      edgeToTarget,
+    ],
+  };
+
+  const revision = counter.increment();
+
+  return { graph: updatedGraph, nodeId, revision };
+}
+
+/**
+ * Generates a unique, stable node ID for a new task node.
+ *
+ * Combines a millisecond timestamp with two independent random segments to
+ * produce a string that is unique within a session. The `"task-"` prefix
+ * distinguishes task nodes from synthetic boundary nodes (`"__start__"` and
+ * `"__end__"`).
+ *
+ * @returns A unique string suitable for use as a {@link GraphNode.id}.
+ */
+function generateNodeId(): string {
+  const ts = Date.now().toString(36);
+  const r1 = Math.random().toString(36).slice(2);
+  const r2 = Math.random().toString(36).slice(2);
+  return `task-${ts}-${r1}${r2}`;
+}

--- a/packages/editor-core/src/index.ts
+++ b/packages/editor-core/src/index.ts
@@ -16,6 +16,7 @@ export type {
 
 export { parseWorkflowSource, serializeWorkflow } from "./source/index.js";
 
+export * from "./commands/index.js";
 export * from "./diagnostics/index.js";
 export * from "./graph/index.js";
 export * from "./state/index.js";

--- a/packages/editor-core/tests/commands/insert-task.test.ts
+++ b/packages/editor-core/tests/commands/insert-task.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+import { insertTask } from "../../src/commands/insert-task.js";
+import type {
+  InsertTaskOptions,
+  InsertTaskResult,
+} from "../../src/commands/insert-task.js";
+import {
+  END_NODE_ID,
+  INITIAL_EDGE_ID,
+  START_NODE_ID,
+  bootstrapWorkflowGraph,
+} from "../../src/graph/index.js";
+import type { WorkflowGraph } from "../../src/graph/index.js";
+import { RevisionCounter } from "../../src/state/revision.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns true if every edge in the graph references existing node IDs. */
+function isGraphConnected(graph: WorkflowGraph): boolean {
+  const nodeIds = new Set(graph.nodes.map((n) => n.id));
+  return graph.edges.every(
+    (e) => nodeIds.has(e.source) && nodeIds.has(e.target)
+  );
+}
+
+/** Returns all direct successors of a node by ID. */
+function successors(graph: WorkflowGraph, nodeId: string): string[] {
+  return graph.edges
+    .filter((e) => e.source === nodeId)
+    .map((e) => e.target);
+}
+
+/** Returns all direct predecessors of a node by ID. */
+function predecessors(graph: WorkflowGraph, nodeId: string): string[] {
+  return graph.edges
+    .filter((e) => e.target === nodeId)
+    .map((e) => e.source);
+}
+
+// ---------------------------------------------------------------------------
+// Basic insertion — start → task → end
+// ---------------------------------------------------------------------------
+
+describe("insertTask — single insertion between start and end", () => {
+  it("produces a graph with 3 nodes and 2 edges", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    expect(result.graph.nodes).toHaveLength(3);
+    expect(result.graph.edges).toHaveLength(2);
+  });
+
+  it("new node has kind 'task'", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    const newNode = result.graph.nodes.find((n) => n.id === result.nodeId);
+    expect(newNode).toBeDefined();
+    expect(newNode?.kind).toBe("task");
+  });
+
+  it("wires start → newNode → end", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    expect(successors(result.graph, START_NODE_ID)).toEqual([result.nodeId]);
+    expect(successors(result.graph, result.nodeId)).toEqual([END_NODE_ID]);
+    expect(predecessors(result.graph, END_NODE_ID)).toEqual([result.nodeId]);
+  });
+
+  it("removes the original edge", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    const originalEdge = result.graph.edges.find(
+      (e) => e.id === INITIAL_EDGE_ID
+    );
+    expect(originalEdge).toBeUndefined();
+  });
+
+  it("increments revision to 1 after the first insertion", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    expect(result.revision).toBe(1);
+    expect(counter.currentRevision).toBe(1);
+  });
+
+  it("stores an optional taskReference on the new node", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, {
+      edgeId: INITIAL_EDGE_ID,
+      taskReference: "my-task",
+    });
+
+    const newNode = result.graph.nodes.find((n) => n.id === result.nodeId);
+    expect(newNode?.taskReference).toBe("my-task");
+  });
+
+  it("new node has no taskReference when none supplied", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    const newNode = result.graph.nodes.find((n) => n.id === result.nodeId);
+    expect(newNode?.taskReference).toBeUndefined();
+  });
+
+  it("does not mutate the original graph", () => {
+    const graph = bootstrapWorkflowGraph();
+    const originalNodeCount = graph.nodes.length;
+    const originalEdgeCount = graph.edges.length;
+    const counter = new RevisionCounter();
+
+    insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    expect(graph.nodes).toHaveLength(originalNodeCount);
+    expect(graph.edges).toHaveLength(originalEdgeCount);
+  });
+
+  it("returned graph is a new object reference", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    expect(result.graph).not.toBe(graph);
+    expect(result.graph.nodes).not.toBe(graph.nodes);
+    expect(result.graph.edges).not.toBe(graph.edges);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple insertions — connectivity invariant
+// ---------------------------------------------------------------------------
+
+describe("insertTask — multiple insertions maintain connectivity", () => {
+  it("two sequential insertions produce 4 nodes and 3 edges", () => {
+    const counter = new RevisionCounter();
+    let graph = bootstrapWorkflowGraph();
+
+    // Insert first task, splitting start → end.
+    const first = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+    graph = first.graph;
+
+    // Find the edge connecting start → first task node, then split it.
+    const edgeStartToFirst = graph.edges.find(
+      (e) => e.source === START_NODE_ID && e.target === first.nodeId
+    );
+    expect(edgeStartToFirst).toBeDefined();
+
+    const second = insertTask(graph, counter, {
+      edgeId: edgeStartToFirst!.id,
+    });
+    graph = second.graph;
+
+    expect(graph.nodes).toHaveLength(4);
+    expect(graph.edges).toHaveLength(3);
+  });
+
+  it("graph stays connected after each insertion", () => {
+    const counter = new RevisionCounter();
+    let graph = bootstrapWorkflowGraph();
+
+    expect(isGraphConnected(graph)).toBe(true);
+
+    let edgeToSplit = INITIAL_EDGE_ID;
+
+    for (let i = 0; i < 5; i++) {
+      const result = insertTask(graph, counter, { edgeId: edgeToSplit });
+      graph = result.graph;
+      expect(isGraphConnected(graph)).toBe(true);
+
+      // For the next iteration, split the edge from the newly inserted node
+      // to the end node so we always have a valid edge to split.
+      const nextEdge = graph.edges.find(
+        (e) => e.source === result.nodeId && e.target === END_NODE_ID
+      );
+      if (nextEdge) {
+        edgeToSplit = nextEdge.id;
+      }
+    }
+  });
+
+  it("revision increments once per insertion across multiple calls", () => {
+    const counter = new RevisionCounter();
+    let graph = bootstrapWorkflowGraph();
+
+    const first = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+    graph = first.graph;
+    expect(first.revision).toBe(1);
+
+    const edgeStartToFirst = graph.edges.find(
+      (e) => e.source === START_NODE_ID
+    )!;
+    const second = insertTask(graph, counter, { edgeId: edgeStartToFirst.id });
+    expect(second.revision).toBe(2);
+    expect(counter.currentRevision).toBe(2);
+  });
+
+  it("all inserted node IDs are unique", () => {
+    const counter = new RevisionCounter();
+    let graph = bootstrapWorkflowGraph();
+    const insertedIds: string[] = [];
+
+    let edgeToSplit = INITIAL_EDGE_ID;
+
+    for (let i = 0; i < 10; i++) {
+      const result = insertTask(graph, counter, { edgeId: edgeToSplit });
+      graph = result.graph;
+      insertedIds.push(result.nodeId);
+
+      const nextEdge = graph.edges.find(
+        (e) => e.source === result.nodeId && e.target === END_NODE_ID
+      );
+      if (nextEdge) {
+        edgeToSplit = nextEdge.id;
+      }
+    }
+
+    const uniqueIds = new Set(insertedIds);
+    expect(uniqueIds.size).toBe(insertedIds.length);
+  });
+
+  it("node IDs never collide with reserved synthetic IDs", () => {
+    const counter = new RevisionCounter();
+    let graph = bootstrapWorkflowGraph();
+    let edgeToSplit = INITIAL_EDGE_ID;
+
+    for (let i = 0; i < 5; i++) {
+      const result = insertTask(graph, counter, { edgeId: edgeToSplit });
+      graph = result.graph;
+      expect(result.nodeId).not.toBe(START_NODE_ID);
+      expect(result.nodeId).not.toBe(END_NODE_ID);
+
+      const nextEdge = graph.edges.find(
+        (e) => e.source === result.nodeId && e.target === END_NODE_ID
+      );
+      if (nextEdge) {
+        edgeToSplit = nextEdge.id;
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases and error handling
+// ---------------------------------------------------------------------------
+
+describe("insertTask — edge cases", () => {
+  it("throws when the specified edgeId does not exist", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+
+    expect(() =>
+      insertTask(graph, counter, { edgeId: "nonexistent-edge" })
+    ).toThrow(/nonexistent-edge/);
+  });
+
+  it("does not increment revision when insertion fails", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+
+    try {
+      insertTask(graph, counter, { edgeId: "bad-edge" });
+    } catch {
+      // expected
+    }
+
+    expect(counter.currentRevision).toBe(0);
+  });
+
+  it("start and end synthetic nodes are preserved after insertion", () => {
+    const graph = bootstrapWorkflowGraph();
+    const counter = new RevisionCounter();
+    const result = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+
+    const startNode = result.graph.nodes.find((n) => n.id === START_NODE_ID);
+    const endNode = result.graph.nodes.find((n) => n.id === END_NODE_ID);
+    expect(startNode).toBeDefined();
+    expect(startNode?.kind).toBe("start");
+    expect(endNode).toBeDefined();
+    expect(endNode?.kind).toBe("end");
+  });
+
+  it("splitting an edge that is not the initial edge also works", () => {
+    const counter = new RevisionCounter();
+    let graph = bootstrapWorkflowGraph();
+
+    // Insert first task → start → task1 → end
+    const first = insertTask(graph, counter, { edgeId: INITIAL_EDGE_ID });
+    graph = first.graph;
+
+    // Find task1 → end edge and split it → start → task1 → task2 → end
+    const task1ToEnd = graph.edges.find(
+      (e) => e.source === first.nodeId && e.target === END_NODE_ID
+    )!;
+
+    const second = insertTask(graph, counter, { edgeId: task1ToEnd.id });
+    graph = second.graph;
+
+    expect(successors(graph, first.nodeId)).toEqual([second.nodeId]);
+    expect(successors(graph, second.nodeId)).toEqual([END_NODE_ID]);
+    expect(isGraphConnected(graph)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `packages/editor-core/src/commands/insert-task.ts` with the `insertTask` function that splits a specified graph edge and inserts a new `"task"` node between the original source and target nodes
- Exports the command from `packages/editor-core/src/commands/index.ts` and re-exports via the package root `src/index.ts`
- The input graph is never mutated; a new `WorkflowGraph` object is always returned
- The revision counter is incremented exactly once per successful insertion; no increment on error

## Test plan

- [x] Single insertion between start and end produces `start → task → end` with 3 nodes and 2 edges
- [x] New node kind is `"task"` with stable unique ID
- [x] Original edge is removed and two replacement edges are wired correctly
- [x] `taskReference` is stored when provided, absent when omitted
- [x] Original graph object is not mutated
- [x] Multiple sequential insertions maintain graph connectivity (`isGraphConnected` helper)
- [x] Revision increments once per insertion across multiple calls
- [x] 10 consecutive insertions produce 10 unique node IDs
- [x] Node IDs never collide with reserved synthetic IDs (`__start__`, `__end__`)
- [x] Throws with the edge ID in the message when `edgeId` is not found
- [x] Revision counter unchanged after a failed insertion
- [x] Synthetic boundary nodes are preserved after insertion

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)