### PR TITLE
feat(editor-core): implement loadWorkflow command (T018)

### DIFF
--- a/packages/editor-core/src/commands/index.ts
+++ b/packages/editor-core/src/commands/index.ts
@@ -1,2 +1,8 @@
 export type { InsertTaskOptions, InsertTaskResult } from "./insert-task.js";
 export { insertTask } from "./insert-task.js";
+export type {
+  LoadWorkflowFailure,
+  LoadWorkflowResult,
+  LoadWorkflowSuccess,
+} from "./load-workflow.js";
+export { loadWorkflow } from "./load-workflow.js";

--- a/packages/editor-core/src/commands/load-workflow.ts
+++ b/packages/editor-core/src/commands/load-workflow.ts
@@ -1,0 +1,84 @@
+import { bootstrapWorkflowGraph } from "../graph/bootstrap.js";
+import type { WorkflowGraph } from "../graph/types.js";
+import { parseWorkflowSource } from "../source/parser.js";
+import type { ParseDiagnostic, WorkflowModel, WorkflowSource } from "../source/types.js";
+import type { RevisionCounter } from "../state/revision.js";
+import type { Revision } from "../state/types.js";
+
+/**
+ * Discriminated result of a successful {@link loadWorkflow} invocation.
+ *
+ * The parsed model and bootstrapped graph are both present so the caller can
+ * update editor state atomically before emitting the `workflowChanged` event.
+ */
+export interface LoadWorkflowSuccess {
+  ok: true;
+  /** The parsed and validated workflow model. */
+  model: WorkflowModel;
+  /**
+   * Initial graph for the loaded workflow.
+   *
+   * A bootstrapped start/end graph is returned. Full model-to-graph projection
+   * is performed by the separate `projectWorkflowModel` utility (T019).
+   */
+  graph: WorkflowGraph;
+  /**
+   * Revision number after the load. Always `1` because the counter is reset
+   * before the first increment on each load.
+   */
+  revision: Revision;
+}
+
+/**
+ * Discriminated result of a failed {@link loadWorkflow} invocation.
+ *
+ * Editor state is not modified when `ok` is `false`.
+ */
+export interface LoadWorkflowFailure {
+  ok: false;
+  /**
+   * One or more structured diagnostics describing why parsing or validation
+   * failed. Always contains at least one entry.
+   */
+  diagnostics: [ParseDiagnostic, ...ParseDiagnostic[]];
+}
+
+/**
+ * Discriminated union result of {@link loadWorkflow}.
+ *
+ * Inspect `result.ok` to branch between success and failure without catching
+ * exceptions.
+ */
+export type LoadWorkflowResult = LoadWorkflowSuccess | LoadWorkflowFailure;
+
+/**
+ * Loads a workflow from a {@link WorkflowSource}, initializing editor state
+ * with the parsed model.
+ *
+ * @remarks
+ * On success:
+ * 1. The source is parsed and validated via the source service.
+ * 2. A fresh bootstrapped graph is created for the loaded workflow.
+ * 3. The revision counter is reset to `0` and incremented to `1`.
+ *
+ * On failure, the diagnostics are returned and editor state is left unchanged.
+ * The caller is responsible for emitting the `workflowChanged` event after a
+ * successful load using the returned `source` and `revision`.
+ *
+ * @param source - The JSON or YAML workflow source document to load.
+ * @param counter - The editor revision counter. Reset and incremented on success.
+ * @returns A {@link LoadWorkflowResult} discriminated by `ok`.
+ */
+export function loadWorkflow(source: WorkflowSource, counter: RevisionCounter): LoadWorkflowResult {
+  const parseResult = parseWorkflowSource(source);
+
+  if (!parseResult.ok) {
+    return { ok: false, diagnostics: parseResult.diagnostics };
+  }
+
+  const graph = bootstrapWorkflowGraph();
+  counter.reset();
+  const revision = counter.increment();
+
+  return { ok: true, model: parseResult.workflow, graph, revision };
+}

--- a/packages/editor-core/src/state/revision.ts
+++ b/packages/editor-core/src/state/revision.ts
@@ -41,4 +41,15 @@ export class RevisionCounter {
     this.#revision += 1;
     return this.#revision;
   }
+
+  /**
+   * Resets the revision counter back to `0`.
+   *
+   * Use this when initializing a fresh editor state, such as when loading a
+   * new workflow document. After calling `reset`, the next call to
+   * {@link increment} will return `1`.
+   */
+  reset(): void {
+    this.#revision = 0;
+  }
 }

--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -42,7 +42,7 @@
 
 **Independent Test**: Load fixtures, edit, and export equivalent source.
 
-- [ ] T018 [P] [US2] Implement load workflow command in `packages/editor-core/src/commands/load-workflow.ts`
+- [x] T018 [P] [US2] Implement load workflow command in `packages/editor-core/src/commands/load-workflow.ts`
 - [ ] T019 [P] [US2] Map loaded model to graph projection in `packages/editor-core/src/graph/project.ts`
 - [ ] T020 [US2] Wire load API on web component host surface in `packages/editor-web-component/src/api/load.ts`
 - [ ] T021 [US2] Add round-trip integration tests in `tests/integration/workflow-roundtrip.spec.ts`


### PR DESCRIPTION
## Summary

- Adds `loadWorkflow` command in `packages/editor-core/src/commands/load-workflow.ts` that accepts a `WorkflowSource`, parses it via the source service, resets the revision counter, and returns a discriminated `LoadWorkflowResult`
- Adds `RevisionCounter.reset()` to support resetting the revision counter on new workflow loads
- Exports all new public symbols from the commands barrel and package index

## What changed

- **`packages/editor-core/src/commands/load-workflow.ts`** (new): `loadWorkflow(source, counter)` function with `LoadWorkflowSuccess`, `LoadWorkflowFailure`, and `LoadWorkflowResult` types
- **`packages/editor-core/src/state/revision.ts`**: added `reset()` method to `RevisionCounter`
- **`packages/editor-core/src/commands/index.ts`**: re-exports new command and types
- **`specs/001-visual-authoring-mvp/tasks.md`**: marks T018 as complete

## Behavior

- Valid JSON/YAML source → parses, bootstraps graph, resets counter to 0, increments to revision 1, returns `{ ok: true, model, graph, revision: 1 }`
- Invalid source → returns `{ ok: false, diagnostics: [...] }` without mutating state
- Caller (web component layer) is responsible for emitting `workflowChanged` using the returned source and revision

Closes #34