### PR TITLE
feat(editor-web-component): implement diagnostics event payload emission (T024)

### DIFF
--- a/packages/editor-web-component/src/events/diagnostics.ts
+++ b/packages/editor-web-component/src/events/diagnostics.ts
@@ -1,0 +1,71 @@
+import type { DiagnosticsCollection } from "@sw-editor/editor-core";
+import type { EventBridge } from "./bridge.js";
+
+/**
+ * Emits `editorDiagnosticsChanged` events via {@link EventBridge} whenever the
+ * diagnostics collection changes, suppressing duplicate emissions.
+ *
+ * Two diagnostic collections are considered identical when their JSON
+ * serializations are equal. This covers both the case of an unchanged error
+ * set after successive validation passes and the common case of repeated
+ * "empty" (fully valid) results.
+ *
+ * Intended as the single point of contact between validation callbacks
+ * (live or explicit) and the event bridge, so deduplication logic is not
+ * scattered across call sites.
+ *
+ * @example
+ * ```ts
+ * const emitter = new DiagnosticsEmitter(bridge);
+ *
+ * // Wire to live validator:
+ * const liveValidator = new LiveValidator((diagnostics) => {
+ *   emitter.handle(diagnostics);
+ * });
+ *
+ * // Wire to explicit validation:
+ * const diagnostics = validateWorkflow(source);
+ * emitter.handle(diagnostics);
+ * ```
+ */
+export class DiagnosticsEmitter {
+  #lastSerialized: string | undefined = undefined;
+
+  /**
+   * Creates a new `DiagnosticsEmitter`.
+   *
+   * @param bridge - The {@link EventBridge} used to dispatch
+   *   `editorDiagnosticsChanged` events on the host element.
+   */
+  constructor(private readonly bridge: EventBridge) {}
+
+  /**
+   * Compares the incoming diagnostics collection against the last emitted one.
+   * If the collections differ, delegates to {@link EventBridge.emitDiagnosticsChanged}
+   * and updates the cached serialization. Identical collections are silently
+   * dropped to prevent redundant events.
+   *
+   * @param diagnostics - The complete diagnostics collection produced by the
+   *   latest validation pass (live or explicit). Pass `[]` for a valid workflow.
+   */
+  handle(diagnostics: DiagnosticsCollection): void {
+    const serialized = JSON.stringify(diagnostics);
+    if (serialized === this.#lastSerialized) {
+      return;
+    }
+    this.#lastSerialized = serialized;
+    this.bridge.emitDiagnosticsChanged(diagnostics);
+  }
+
+  /**
+   * Resets the cached diagnostics state so the next {@link handle} call will
+   * always emit an event regardless of the incoming collection.
+   *
+   * Call this when the workflow document is replaced (e.g. after a load
+   * operation) to ensure the host receives fresh diagnostics for the new
+   * source even if the collection is structurally identical to the previous one.
+   */
+  reset(): void {
+    this.#lastSerialized = undefined;
+  }
+}

--- a/packages/editor-web-component/src/events/index.ts
+++ b/packages/editor-web-component/src/events/index.ts
@@ -8,6 +8,7 @@
  * @module events
  */
 export { EventBridge } from "./bridge.js";
+export { DiagnosticsEmitter } from "./diagnostics.js";
 export type {
   EditorDiagnosticsChangedEvent,
   EditorErrorEvent,

--- a/packages/editor-web-component/tests/events/diagnostics.test.ts
+++ b/packages/editor-web-component/tests/events/diagnostics.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EditorEventName } from "@sw-editor/editor-host-client";
+import type { EditorDiagnosticsChangedPayload } from "@sw-editor/editor-host-client";
+import type { DiagnosticsCollection } from "@sw-editor/editor-core";
+import { EventBridge } from "../../src/events/bridge.js";
+import { DiagnosticsEmitter } from "../../src/events/diagnostics.js";
+
+/** Captures the next event of `name` on `target` and returns its detail. */
+function captureEvent<T>(target: EventTarget, name: string): Promise<T> {
+  return new Promise<T>((resolve) => {
+    target.addEventListener(name, (e) => resolve((e as CustomEvent<T>).detail), { once: true });
+  });
+}
+
+describe("DiagnosticsEmitter", () => {
+  const VERSION = "1.0.0";
+  const DIAGNOSTIC_A: DiagnosticsCollection = [
+    { ruleId: "required-field", severity: "error", message: "Missing name", location: "/name" },
+  ];
+  const DIAGNOSTIC_B: DiagnosticsCollection = [
+    { ruleId: "schema.validation", severity: "error", message: "Invalid format", location: "/do" },
+  ];
+
+  let target: EventTarget;
+  let bridge: EventBridge;
+  let emitter: DiagnosticsEmitter;
+
+  beforeEach(() => {
+    target = new EventTarget();
+    bridge = new EventBridge(target, VERSION);
+    emitter = new DiagnosticsEmitter(bridge);
+  });
+
+  describe("handle — emission", () => {
+    it("emits editorDiagnosticsChanged on first call with diagnostics", async () => {
+      const detailPromise = captureEvent<EditorDiagnosticsChangedPayload>(
+        target,
+        EditorEventName.editorDiagnosticsChanged,
+      );
+
+      emitter.handle(DIAGNOSTIC_A);
+
+      const detail = await detailPromise;
+      expect(detail.diagnostics).toEqual(DIAGNOSTIC_A);
+    });
+
+    it("emits editorDiagnosticsChanged on first call with empty collection", async () => {
+      const detailPromise = captureEvent<EditorDiagnosticsChangedPayload>(
+        target,
+        EditorEventName.editorDiagnosticsChanged,
+      );
+
+      emitter.handle([]);
+
+      const detail = await detailPromise;
+      expect(detail.diagnostics).toEqual([]);
+    });
+
+    it("payload includes version and monotonic revision from the bridge", async () => {
+      const detailPromise = captureEvent<EditorDiagnosticsChangedPayload>(
+        target,
+        EditorEventName.editorDiagnosticsChanged,
+      );
+
+      emitter.handle(DIAGNOSTIC_A);
+
+      const detail = await detailPromise;
+      expect(detail.version).toBe(VERSION);
+      expect(typeof detail.revision).toBe("number");
+      expect(detail.revision).toBeGreaterThanOrEqual(1);
+    });
+
+    it("emits when diagnostics change from one non-empty collection to another", async () => {
+      emitter.handle(DIAGNOSTIC_A);
+
+      const detailPromise = captureEvent<EditorDiagnosticsChangedPayload>(
+        target,
+        EditorEventName.editorDiagnosticsChanged,
+      );
+
+      emitter.handle(DIAGNOSTIC_B);
+
+      const detail = await detailPromise;
+      expect(detail.diagnostics).toEqual(DIAGNOSTIC_B);
+    });
+
+    it("emits when diagnostics change from non-empty to empty", async () => {
+      emitter.handle(DIAGNOSTIC_A);
+
+      const detailPromise = captureEvent<EditorDiagnosticsChangedPayload>(
+        target,
+        EditorEventName.editorDiagnosticsChanged,
+      );
+
+      emitter.handle([]);
+
+      const detail = await detailPromise;
+      expect(detail.diagnostics).toEqual([]);
+    });
+
+    it("emits when diagnostics change from empty to non-empty", async () => {
+      emitter.handle([]);
+
+      const detailPromise = captureEvent<EditorDiagnosticsChangedPayload>(
+        target,
+        EditorEventName.editorDiagnosticsChanged,
+      );
+
+      emitter.handle(DIAGNOSTIC_A);
+
+      const detail = await detailPromise;
+      expect(detail.diagnostics).toEqual(DIAGNOSTIC_A);
+    });
+  });
+
+  describe("handle — deduplication", () => {
+    it("does not re-emit when the same non-empty collection is provided twice", () => {
+      const listener = vi.fn();
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, listener);
+
+      emitter.handle(DIAGNOSTIC_A);
+      emitter.handle([...DIAGNOSTIC_A]); // structurally equal, different reference
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-emit when the same empty collection is provided twice", () => {
+      const listener = vi.fn();
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, listener);
+
+      emitter.handle([]);
+      emitter.handle([]);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not re-emit after multiple identical passes", () => {
+      const listener = vi.fn();
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, listener);
+
+      emitter.handle(DIAGNOSTIC_A);
+      emitter.handle(DIAGNOSTIC_A);
+      emitter.handle(DIAGNOSTIC_A);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("reset", () => {
+    it("forces re-emission of an identical collection after reset", () => {
+      const listener = vi.fn();
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, listener);
+
+      emitter.handle([]);
+      emitter.handle([]); // deduplicated — 1 call total so far
+
+      emitter.reset();
+
+      emitter.handle([]); // reset clears cache — should emit again
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("forces re-emission of identical diagnostics after reset", () => {
+      const listener = vi.fn();
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, listener);
+
+      emitter.handle(DIAGNOSTIC_A);
+      emitter.reset();
+      emitter.handle(DIAGNOSTIC_A);
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("after reset, deduplication resumes for subsequent identical calls", () => {
+      const listener = vi.fn();
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, listener);
+
+      emitter.reset();
+      emitter.handle(DIAGNOSTIC_A); // emits after reset
+      emitter.handle(DIAGNOSTIC_A); // deduplicated
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("live validator integration pattern", () => {
+    it("only emits once when live validator repeatedly returns the same diagnostics", () => {
+      const listener = vi.fn();
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, listener);
+
+      // Simulate multiple debounced validator callbacks with identical results
+      for (let i = 0; i < 5; i++) {
+        emitter.handle(DIAGNOSTIC_A);
+      }
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("emits correct sequence when diagnostics alternate between passes", async () => {
+      const received: DiagnosticsCollection[] = [];
+      target.addEventListener(EditorEventName.editorDiagnosticsChanged, (e) => {
+        received.push((e as CustomEvent<EditorDiagnosticsChangedPayload>).detail.diagnostics);
+      });
+
+      emitter.handle(DIAGNOSTIC_A); // emit 1
+      emitter.handle(DIAGNOSTIC_A); // skip (duplicate)
+      emitter.handle([]);           // emit 2
+      emitter.handle([]);           // skip (duplicate)
+      emitter.handle(DIAGNOSTIC_B); // emit 3
+
+      expect(received).toHaveLength(3);
+      expect(received[0]).toEqual(DIAGNOSTIC_A);
+      expect(received[1]).toEqual([]);
+      expect(received[2]).toEqual(DIAGNOSTIC_B);
+    });
+  });
+});

--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -55,7 +55,7 @@
 
 - [x] T022 [P] [US3] Implement debounced validation trigger in `packages/editor-core/src/validation/live-validator.ts`
 - [x] T023 [P] [US3] Implement explicit full validation command in `packages/editor-core/src/validation/full-validator.ts`
-- [ ] T024 [US3] Implement diagnostics event payload emission in `packages/editor-web-component/src/events/diagnostics.ts`
+- [x] T024 [US3] Implement diagnostics event payload emission in `packages/editor-web-component/src/events/diagnostics.ts`
 - [ ] T025 [US3] Implement diagnostics UI mapping and fallback behavior in `packages/editor-web-component/src/diagnostics/rendering.ts`
 - [ ] T026 [US3] Add contract tests for diagnostics payloads in `tests/contract/editor-diagnostics.contract.spec.ts`
 


### PR DESCRIPTION
## Summary

- Adds `DiagnosticsEmitter` in `packages/editor-web-component/src/events/diagnostics.ts` — a thin wrapper around `EventBridge` that emits `editorDiagnosticsChanged` CustomEvents when the diagnostics collection changes and suppresses duplicate emissions (JSON-equality deduplication).
- Exports `DiagnosticsEmitter` from the `events` barrel (`events/index.ts`).
- Adds 14 unit tests covering: first emission, payload shape, deduplication, `reset()` behaviour, and sequence-of-emissions integration patterns.
- Marks T024 complete in `specs/001-visual-authoring-mvp/tasks.md`.

## Test plan

- [x] `pnpm --filter @sw-editor/editor-web-component test` — all 50 tests pass (14 new, 36 existing)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)