### PR TITLE
docs: finalize README.md (task #83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Additional scripts available at the root:
 
 ## Spec Kit Workflow
 
-This repository uses [GitHub Spec Kit](https://github.com/JBBianchi/sw-editor) feature packages to keep requirements, technical plans, and implementation tasks synchronized.
+This repository uses the Spec Kit feature package workflow to keep requirements, technical plans, and implementation tasks synchronized.
 
 All feature work follows a structured lifecycle:
 


### PR DESCRIPTION
## Summary

- Task #82 (T2) already wrote the complete 8-section README to the repository root, replacing the original two-line placeholder.
- This PR fixes one inaccuracy introduced in T2: the \"Spec Kit Workflow\" section contained a `[GitHub Spec Kit]` link pointing to `https://github.com/JBBianchi/sw-editor` — the current repository itself — which was circular and misleading. The link is replaced with plain descriptive text.

## Acceptance Criteria Verification

| Criterion | Status |
|-----------|--------|
| README contains all 8 sections from T2 | ✅ Intro, Key Principles, Architecture Overview, Feature Packages, Prerequisites & Quick Start, Spec Kit Workflow, Contributing, License |
| File is valid GitHub-flavored Markdown | ✅ |
| No placeholder text remains | ✅ |

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)