### PR TITLE
docs(specs): align feature summaries in specs/README.md with root README

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -4,10 +4,12 @@ This repository now uses GitHub Spec Kit feature packages under `specs/`.
 
 ## Feature Set
 
-- `001-visual-authoring-mvp`
-- `002-nested-tasks-ux`
-- `003-branching-control-flow`
-- `004-extensibility-customization`
+| Feature | One-Line Summary |
+|---------|-----------------|
+| [`001-visual-authoring-mvp`](001-visual-authoring-mvp/) | Embeddable visual authoring for Serverless Workflow with source round-trip, insertion UX, and live diagnostics. |
+| [`002-nested-tasks-ux`](002-nested-tasks-ux/) | Visual authoring support for nested task structures with expanded default rendering. |
+| [`003-branching-control-flow`](003-branching-control-flow/) | Panel-driven authoring for transition, if, switch, fork, and try-catch behavior with route projection. |
+| [`004-extensibility-customization`](004-extensibility-customization/) | Plugin architecture for custom rendering, validation, commands, and slot-based UI extensions. |
 
 Each feature package contains:
 


### PR DESCRIPTION
## Summary

- Replaced bare bullet list of feature names in `specs/README.md` with a summary table that matches the one-line descriptions used in the root `README.md`
- Added relative links to each feature folder for navigability
- No factual changes — wording taken directly from the root README

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)