### PR TITLE
fix(build): resolve TypeScript errors blocking pnpm build across all packages

### DIFF
--- a/packages/editor-renderer-rete-lit/src/rete-lit-adapter.ts
+++ b/packages/editor-renderer-rete-lit/src/rete-lit-adapter.ts
@@ -7,13 +7,15 @@
  * @module
  */
 
-import { ClassicPreset, GetSchemes, NodeEditor } from "rete";
+import { ClassicPreset, NodeEditor } from "rete";
+import type { GetSchemes } from "rete";
 import { AreaExtensions, AreaPlugin } from "rete-area-plugin";
 import {
   ConnectionPlugin,
   Presets as ConnectionPresets,
 } from "rete-connection-plugin";
-import { LitPlugin, LitArea2D, Presets } from "@retejs/lit-plugin";
+import { LitPlugin, Presets } from "@retejs/lit-plugin";
+import type { LitArea2D } from "@retejs/lit-plugin";
 
 import type {
   RendererAdapter,
@@ -156,11 +158,11 @@ class TrackingSelector extends AreaExtensions.Selector<SelectorEntity> {
    * @param entity - The entity to add.
    * @param accumulate - Whether to keep existing selections.
    */
-  override add(entity: SelectorEntity, accumulate: boolean): void {
+  override async add(entity: SelectorEntity, accumulate: boolean): Promise<void> {
     if (!accumulate) {
       this.selected.clear();
     }
-    super.add(entity, accumulate);
+    await super.add(entity, accumulate);
     this.selected.set(this.entityKey(entity), entity);
     this.scheduleEmit();
   }
@@ -170,13 +172,13 @@ class TrackingSelector extends AreaExtensions.Selector<SelectorEntity> {
    *
    * @param entity - The entity to remove.
    */
-  override remove(entity: SelectorEntity): void {
-    super.remove(entity);
+  override async remove(entity: Pick<SelectorEntity, "id" | "label">): Promise<void> {
+    await super.remove(entity);
     this.selected.delete(this.entityKey(entity));
     this.scheduleEmit();
   }
 
-  private entityKey(entity: SelectorEntity): string {
+  private entityKey(entity: Pick<SelectorEntity, "id" | "label">): string {
     return `${entity.label}:${entity.id}`;
   }
 

--- a/packages/editor-web-component/src/graph/insertion-ui.ts
+++ b/packages/editor-web-component/src/graph/insertion-ui.ts
@@ -333,7 +333,7 @@ export class InsertionUI {
       item.setAttribute("role", "menuitem");
       item.className = "sw-task-menu__item";
       item.textContent = taskType.label;
-      item.dataset.taskTypeId = taskType.id;
+      item.dataset["taskTypeId"] = taskType.id;
 
       item.addEventListener("click", () => {
         this.closeTaskMenu();

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
## Summary

- **`tsconfig.base.json`**: Added `"DOM"` to `lib` so that `setTimeout`, `clearTimeout`, `queueMicrotask`, and `HTMLElement` are globally typed across all packages. Packages cross-reference each other's source files via workspace `exports`, so the DOM lib must be present in the shared base config.
- **`editor-renderer-rete-lit/src/rete-lit-adapter.ts`**: Separated `GetSchemes` and `LitArea2D` into type-only imports (`import type`) to satisfy `verbatimModuleSyntax`. Made `TrackingSelector.add` and `TrackingSelector.remove` async (`Promise<void>`) to match the signature of the `rete-area-plugin` `Selector` base class.
- **`editor-web-component/src/graph/insertion-ui.ts`**: Changed `item.dataset.taskTypeId` to `item.dataset["taskTypeId"]` (bracket notation) to satisfy `noPropertyAccessFromIndexSignature`.

## Verification

- `pnpm install` exits 0.
- `pnpm build` exits 0 with zero error-level output across all 6 packages:
  - `packages/editor-core/`
  - `packages/editor-web-component/`
  - `packages/editor-host-client/`
  - `packages/editor-renderer-contract/`
  - `packages/editor-renderer-rete-lit/`
  - `packages/editor-renderer-react-flow/`

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)