### PR TITLE
feat(examples): add example/ directory with vanilla-js and host-events scenarios

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,38 @@
+# Examples
+
+Standalone host-integration scenarios demonstrating how to embed and interact
+with the `sw-editor` web component.
+
+## Scenarios
+
+| Directory | Description | Start command |
+|-----------|-------------|---------------|
+| [`vanilla-js/`](./vanilla-js/) | Load a workflow fixture and export it as JSON/YAML | `pnpm --filter @sw-editor/example-vanilla-js dev` |
+| [`host-events/`](./host-events/) | Subscribe to diagnostics and capability events | `pnpm --filter @sw-editor/example-host-events dev` |
+
+## Prerequisites
+
+- Node.js 24 LTS
+- pnpm 10.30.3 (`corepack enable && corepack prepare`)
+
+## Quick start
+
+```bash
+# From the repository root — installs all workspace packages including examples
+pnpm install
+
+# Start the vanilla-js example
+pnpm --filter @sw-editor/example-vanilla-js dev
+
+# Start the host-events example (in a separate terminal)
+pnpm --filter @sw-editor/example-host-events dev
+```
+
+Both examples are served at <http://localhost:5173> by default (Vite picks the
+next available port when the first is occupied).
+
+## No external network dependencies
+
+All fixture data is bundled at build time.  Neither example makes runtime
+requests to external hosts, satisfying the project constitution's
+"no runtime network calls from editor core" principle.

--- a/example/host-events/README.md
+++ b/example/host-events/README.md
@@ -1,0 +1,61 @@
+# Example: Host Events
+
+Demonstrates subscribing to Serverless Workflow editor events and querying
+renderer capabilities using the host–editor contract API.
+
+## What it shows
+
+- Subscribing to `workflowChanged`, `editorDiagnosticsChanged`,
+  `editorSelectionChanged`, and `editorError` events via `addEventListener`.
+- Displaying received events in a live event log.
+- Querying the renderer capability snapshot (`getCapabilities`).
+- How a real integration wires listeners on the `<sw-editor>` element (see
+  inline comments in `index.html`).
+
+For the standalone demo, events are simulated using `EventBridge` on a plain
+`EventTarget`.  In a real integration the bridge is internal to the editor
+bundle — the host only calls `addEventListener` on the mounted element.
+
+## Prerequisites
+
+- Node.js 24 LTS
+- pnpm 10.30.3 (managed via Corepack: `corepack enable && corepack prepare`)
+
+## Start
+
+From the **repository root**, install dependencies once:
+
+```bash
+pnpm install
+```
+
+Then start the dev server for this example:
+
+```bash
+pnpm --filter @sw-editor/example-host-events dev
+```
+
+The page is served at <http://localhost:5173> by default.
+
+## Using the page
+
+| Button | What it does |
+|--------|-------------|
+| Simulate workflow load event | Fires a `workflowChanged` event |
+| Simulate diagnostics event | Fires `editorDiagnosticsChanged` with one warning |
+| Simulate selection event | Fires `editorSelectionChanged` for a node |
+| Simulate error event | Fires `editorError` for a renderer init failure |
+| Query capabilities | Populates the renderer capabilities table |
+| Clear log | Resets the event log |
+
+All received events appear in the **Event log** panel with a timestamp and
+payload summary.
+
+## File overview
+
+| File | Purpose |
+|------|---------|
+| `index.html` | Entry HTML with event-log and capabilities UI |
+| `main.ts` | Event subscription, simulation buttons, capability rendering |
+| `vite.config.ts` | Vite config with workspace-package aliases |
+| `package.json` | Scripts and workspace dependencies |

--- a/example/host-events/index.html
+++ b/example/host-events/index.html
@@ -1,0 +1,153 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>sw-editor — Host Events Example</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 900px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        background: #f8f9fa;
+        color: #212529;
+      }
+      h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+      p.lead { color: #555; margin-top: 0; }
+      .controls { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+      button {
+        background: #0d6efd;
+        color: #fff;
+        border: none;
+        padding: 0.4rem 0.9rem;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.875rem;
+      }
+      button:hover { background: #0b5ed7; }
+      button.secondary { background: #6c757d; }
+      button.secondary:hover { background: #5c636a; }
+      button.danger { background: #dc3545; }
+      button.danger:hover { background: #bb2d3b; }
+      .panels {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1rem;
+      }
+      @media (max-width: 600px) { .panels { grid-template-columns: 1fr; } }
+      .panel {
+        background: #fff;
+        border: 1px solid #dee2e6;
+        border-radius: 6px;
+        padding: 1rem;
+      }
+      .panel h2 {
+        font-size: 0.95rem;
+        margin: 0 0 0.5rem;
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+      }
+      .badge {
+        background: #0d6efd;
+        color: #fff;
+        border-radius: 999px;
+        font-size: 0.7rem;
+        padding: 0.1rem 0.5rem;
+        min-width: 1.4rem;
+        text-align: center;
+      }
+      .event-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        max-height: 260px;
+        overflow-y: auto;
+        font-size: 0.8rem;
+      }
+      .event-list li {
+        border-bottom: 1px solid #f0f0f0;
+        padding: 0.35rem 0;
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 0.4rem;
+        align-items: start;
+      }
+      .event-list li:last-child { border-bottom: none; }
+      .event-time { color: #888; white-space: nowrap; }
+      .event-body { word-break: break-word; }
+      .event-body .type {
+        font-weight: 600;
+        display: inline-block;
+        margin-bottom: 0.1rem;
+      }
+      .type-workflowChanged { color: #198754; }
+      .type-editorDiagnosticsChanged { color: #fd7e14; }
+      .type-editorSelectionChanged { color: #0dcaf0; }
+      .type-editorError { color: #dc3545; }
+      .empty { color: #aaa; font-size: 0.85rem; font-style: italic; }
+      .cap-table { width: 100%; border-collapse: collapse; font-size: 0.82rem; }
+      .cap-table td { padding: 0.25rem 0.35rem; border-bottom: 1px solid #f0f0f0; }
+      .cap-table td:first-child { color: #555; width: 55%; }
+      .cap-table tr:last-child td { border-bottom: none; }
+    </style>
+  </head>
+  <body>
+    <h1>sw-editor — Host Events Integration</h1>
+    <p class="lead">
+      Demonstrates subscribing to editor events and querying renderer
+      capabilities through the host–editor contract API.
+    </p>
+
+    <div class="controls">
+      <button id="btn-simulate-load">Simulate workflow load event</button>
+      <button id="btn-simulate-diag">Simulate diagnostics event</button>
+      <button id="btn-simulate-selection">Simulate selection event</button>
+      <button id="btn-simulate-error" class="secondary">Simulate error event</button>
+      <button id="btn-get-cap">Query capabilities</button>
+      <button id="btn-clear" class="danger">Clear log</button>
+    </div>
+
+    <div class="panels">
+      <div class="panel">
+        <h2>
+          Event log
+          <span class="badge" id="event-count">0</span>
+        </h2>
+        <ul class="event-list" id="event-list">
+          <li><span class="empty">No events yet — click a button above.</span></li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h2>Renderer capabilities</h2>
+        <p class="empty" id="cap-placeholder">
+          Click "Query capabilities" to populate.
+        </p>
+        <table class="cap-table" id="cap-table" hidden>
+          <tbody id="cap-body"></tbody>
+        </table>
+      </div>
+    </div>
+
+    <!--
+      In a full integration, mount the editor element and listen on it:
+
+        <sw-editor id="editor" style="width:100%;height:400px;"></sw-editor>
+
+        const editor = document.getElementById('editor');
+        editor.addEventListener('editorDiagnosticsChanged', (e) => {
+          console.log('diagnostics:', e.detail.diagnostics);
+        });
+        editor.addEventListener('workflowChanged', (e) => {
+          console.log('source:', e.detail.source);
+        });
+
+        // Query capabilities after mount:
+        const caps = await editor.getCapabilities();
+    -->
+
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/example/host-events/main.ts
+++ b/example/host-events/main.ts
@@ -1,0 +1,263 @@
+/**
+ * Host-events integration example for `@sw-editor/editor-web-component`.
+ *
+ * Demonstrates the event subscription API:
+ *   - `workflowChanged` — emitted when the workflow source is updated.
+ *   - `editorDiagnosticsChanged` — emitted after every validation pass.
+ *   - `editorSelectionChanged` — emitted when the in-editor selection changes.
+ *   - `editorError` — emitted on unrecoverable editor errors.
+ *
+ * For this standalone demo the editor events are simulated by creating an
+ * {@link EventBridge} on a plain `EventTarget`.  In a real integration the
+ * target is the `<sw-editor>` custom element and the bridge is internal to
+ * the editor bundle — the host only needs to call `addEventListener`.
+ *
+ * Capabilities are provided via the static snapshot from
+ * `@sw-editor/editor-host-client`, matching what `editor.getCapabilities()`
+ * would return when the rete-lit renderer bundle is active.
+ *
+ * No runtime external network calls are made.
+ *
+ * @module example/host-events/main
+ */
+
+import { EventBridge } from "@sw-editor/editor-web-component";
+import {
+  EditorEventName,
+  CONTRACT_VERSION,
+  TARGET_VERSION,
+  SUPPORTED_VERSIONS,
+} from "@sw-editor/editor-host-client";
+import type {
+  WorkflowChangedPayload,
+  EditorDiagnosticsChangedPayload,
+  EditorSelectionChangedPayload,
+  EditorErrorPayload,
+  CapabilitySnapshot,
+} from "@sw-editor/editor-host-client";
+
+// ---------------------------------------------------------------------------
+// Shared event target — in a real integration this would be the <sw-editor>
+// custom element.
+// ---------------------------------------------------------------------------
+
+const editorTarget = new EventTarget();
+
+// The EventBridge emits typed CustomEvents on editorTarget.  In production the
+// bridge is internal to the editor bundle; the host only observes events.
+const bridge = new EventBridge(editorTarget, CONTRACT_VERSION);
+
+// ---------------------------------------------------------------------------
+// DOM refs
+// ---------------------------------------------------------------------------
+
+const eventList = document.getElementById("event-list") as HTMLUListElement;
+const eventCount = document.getElementById("event-count") as HTMLSpanElement;
+const capPlaceholder = document.getElementById("cap-placeholder") as HTMLParagraphElement;
+const capTable = document.getElementById("cap-table") as HTMLTableElement;
+const capBody = document.getElementById("cap-body") as HTMLTableSectionElement;
+
+const btnSimulateLoad = document.getElementById("btn-simulate-load") as HTMLButtonElement;
+const btnSimulateDiag = document.getElementById("btn-simulate-diag") as HTMLButtonElement;
+const btnSimulateSelection = document.getElementById("btn-simulate-selection") as HTMLButtonElement;
+const btnSimulateError = document.getElementById("btn-simulate-error") as HTMLButtonElement;
+const btnGetCap = document.getElementById("btn-get-cap") as HTMLButtonElement;
+const btnClear = document.getElementById("btn-clear") as HTMLButtonElement;
+
+// ---------------------------------------------------------------------------
+// Event subscriptions
+// The host registers listeners on the target element (or a parent via bubbling).
+// ---------------------------------------------------------------------------
+
+/**
+ * Handles `workflowChanged` events from the editor.
+ *
+ * @param event - The typed workflow-changed event.
+ */
+editorTarget.addEventListener(EditorEventName.workflowChanged, (event) => {
+  const { source, version, revision } = (event as CustomEvent<WorkflowChangedPayload>).detail;
+  appendEvent(
+    EditorEventName.workflowChanged,
+    `format=${source.format} revision=${revision} contract=${version}`,
+  );
+});
+
+/**
+ * Handles `editorDiagnosticsChanged` events from the editor.
+ *
+ * @param event - The typed diagnostics event.
+ */
+editorTarget.addEventListener(EditorEventName.editorDiagnosticsChanged, (event) => {
+  const { diagnostics, revision } = (event as CustomEvent<EditorDiagnosticsChangedPayload>).detail;
+  const counts = { errors: 0, warnings: 0, infos: 0 };
+  for (const d of diagnostics) {
+    if (d.severity === "error") counts.errors++;
+    else if (d.severity === "warning") counts.warnings++;
+    else counts.infos++;
+  }
+  const { errors, warnings, infos } = counts;
+  const summary = `revision=${revision} errors=${errors} warnings=${warnings} infos=${infos}`;
+  appendEvent(EditorEventName.editorDiagnosticsChanged, summary);
+});
+
+/**
+ * Handles `editorSelectionChanged` events from the editor.
+ *
+ * @param event - The typed selection event.
+ */
+editorTarget.addEventListener(EditorEventName.editorSelectionChanged, (event) => {
+  const { selection, revision } = (event as CustomEvent<EditorSelectionChangedPayload>).detail;
+  const id =
+    selection == null ? "null" : selection.kind === "node" ? selection.nodeId : selection.edgeId;
+  const desc = selection ? `${selection.kind}=${id}` : "null";
+  appendEvent(EditorEventName.editorSelectionChanged, `revision=${revision} selection=${desc}`);
+});
+
+/**
+ * Handles `editorError` events from the editor.
+ *
+ * @param event - The typed error event.
+ */
+editorTarget.addEventListener(EditorEventName.editorError, (event) => {
+  const { code, message, revision } = (event as CustomEvent<EditorErrorPayload>).detail;
+  appendEvent(EditorEventName.editorError, `revision=${revision} code=${code} — ${message}`);
+});
+
+// ---------------------------------------------------------------------------
+// Simulation buttons
+// ---------------------------------------------------------------------------
+
+/** Simulates a workflow-load event from the editor. */
+btnSimulateLoad.addEventListener("click", () => {
+  bridge.emitWorkflowChanged({ format: "json", content: '{"document":{"dsl":"1.0.0"}}' });
+});
+
+/** Simulates a diagnostics event with one warning. */
+btnSimulateDiag.addEventListener("click", () => {
+  bridge.emitDiagnosticsChanged([
+    {
+      ruleId: "template-expression-in-endpoint",
+      severity: "warning",
+      message: "Task 'fetchUser' endpoint contains a template expression",
+      location: "do[0].fetchUser.with.endpoint",
+    },
+  ]);
+});
+
+/** Simulates a node-selection event. */
+btnSimulateSelection.addEventListener("click", () => {
+  bridge.emitSelectionChanged({ kind: "node", nodeId: "fetchUser" });
+});
+
+/** Simulates an unrecoverable editor error. */
+btnSimulateError.addEventListener("click", () => {
+  bridge.emitError("RENDERER_INIT_FAILED", "The renderer failed to initialize.");
+});
+
+/** Queries and displays the renderer capability snapshot. */
+btnGetCap.addEventListener("click", () => {
+  const caps: CapabilitySnapshot = {
+    contractVersion: CONTRACT_VERSION,
+    targetVersion: TARGET_VERSION,
+    supportedVersions: [...SUPPORTED_VERSIONS],
+    rendererId: "rete-lit",
+    rendererCapabilities: {
+      rendererId: "rete-lit",
+      rendererVersion: "0.0.0",
+      supportsNodeRendererPlugins: false,
+      supportsNestedInlineProjection: false,
+      supportsRouteOverlayProjection: false,
+      knownLimits: ["Nested inline projection not yet implemented"],
+    },
+  };
+  renderCapabilities(caps);
+  console.log("[sw-editor example] Capabilities:", caps);
+});
+
+/** Clears the event log. */
+btnClear.addEventListener("click", () => {
+  eventList.innerHTML =
+    '<li><span class="empty">No events yet — click a button above.</span></li>';
+  eventCount.textContent = "0";
+  _eventTotal = 0;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _eventTotal = 0;
+
+/**
+ * Appends a new event entry to the event log list.
+ *
+ * @param type - The event name string.
+ * @param detail - Short human-readable detail string for the entry.
+ */
+function appendEvent(type: string, detail: string): void {
+  // Remove the placeholder on first event.
+  const placeholder = eventList.querySelector(".empty");
+  if (placeholder) placeholder.parentElement?.remove();
+
+  _eventTotal++;
+  eventCount.textContent = String(_eventTotal);
+
+  const now = new Date().toLocaleTimeString();
+  const li = document.createElement("li");
+  li.innerHTML = `
+    <span class="event-time">${now}</span>
+    <span class="event-body">
+      <span class="type type-${type}">${type}</span><br>
+      ${escapeHtml(detail)}
+    </span>
+  `;
+  eventList.prepend(li);
+}
+
+/**
+ * Renders a capability snapshot into the capabilities table.
+ *
+ * @param caps - The capability snapshot to display.
+ */
+function renderCapabilities(caps: CapabilitySnapshot): void {
+  capPlaceholder.hidden = true;
+  capTable.hidden = false;
+
+  const rows: [string, string][] = [
+    ["Contract version", caps.contractVersion],
+    ["Target SW version", caps.targetVersion],
+    ["Supported versions", caps.supportedVersions.join(", ")],
+    ["Renderer ID", caps.rendererId],
+    ["Renderer version", caps.rendererCapabilities.rendererVersion],
+    ["Node renderer plugins", caps.rendererCapabilities.supportsNodeRendererPlugins ? "yes" : "no"],
+    [
+      "Nested inline projection",
+      caps.rendererCapabilities.supportsNestedInlineProjection ? "yes" : "no",
+    ],
+    [
+      "Route overlay projection",
+      caps.rendererCapabilities.supportsRouteOverlayProjection ? "yes" : "no",
+    ],
+  ];
+  if (caps.rendererCapabilities.knownLimits?.length) {
+    rows.push(["Known limits", caps.rendererCapabilities.knownLimits.join("; ")]);
+  }
+
+  capBody.innerHTML = rows
+    .map(([label, value]) => `<tr><td>${escapeHtml(label)}</td><td>${escapeHtml(value)}</td></tr>`)
+    .join("");
+}
+
+/**
+ * Escapes a string for safe insertion into innerHTML.
+ *
+ * @param str - The string to escape.
+ * @returns HTML-safe string.
+ */
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/example/host-events/package.json
+++ b/example/host-events/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@sw-editor/example-host-events",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Host-events example: subscribe to editor diagnostics and capability events",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@sw-editor/editor-host-client": "workspace:*",
+    "@sw-editor/editor-web-component": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0"
+  }
+}

--- a/example/host-events/vite.config.ts
+++ b/example/host-events/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+/**
+ * Vite configuration for the host-events example.
+ *
+ * Resolves workspace packages from their TypeScript source so the example
+ * can be run with `pnpm dev` without a separate build step for each package.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@sw-editor/editor-host-client": resolve(
+        __dirname,
+        "../../packages/editor-host-client/src/index.ts",
+      ),
+      "@sw-editor/editor-web-component": resolve(
+        __dirname,
+        "../../packages/editor-web-component/src/index.ts",
+      ),
+      "@sw-editor/editor-core": resolve(
+        __dirname,
+        "../../packages/editor-core/src/index.ts",
+      ),
+    },
+  },
+});

--- a/example/vanilla-js/README.md
+++ b/example/vanilla-js/README.md
@@ -1,0 +1,51 @@
+# Example: Vanilla JS
+
+Demonstrates embedding the Serverless Workflow editor host-client in a
+plain-HTML + TypeScript page.  Bundled by [Vite](https://vite.dev) so no
+separate compile step is required before launching.
+
+## What it shows
+
+- Loading a workflow fixture (JSON) via a bundled import — no runtime network
+  calls.
+- Registering it as the active source with `setCurrentSource`.
+- Exporting the workflow as JSON or YAML via `exportWorkflowSource`.
+- How to embed `<sw-editor>` once a built editor bundle is available (see
+  inline comments in `index.html`).
+
+## Prerequisites
+
+- Node.js 24 LTS
+- pnpm 10.30.3 (managed via Corepack: `corepack enable && corepack prepare`)
+
+## Start
+
+From the **repository root**, install dependencies once:
+
+```bash
+pnpm install
+```
+
+Then start the dev server for this example:
+
+```bash
+pnpm --filter @sw-editor/example-vanilla-js dev
+```
+
+The page is served at <http://localhost:5173> by default.
+
+## Using the page
+
+1. Click **"Load simple.json fixture"** — the `simple-http-call` workflow is
+   parsed and registered as the active source.
+2. Click **"Export as JSON"** or **"Export as YAML"** — the exported content
+   appears in the output panel and is also logged to the browser console.
+
+## File overview
+
+| File | Purpose |
+|------|---------|
+| `index.html` | Entry HTML; includes notes on how to embed `<sw-editor>` |
+| `main.ts` | Host integration logic using `@sw-editor/editor-host-client` |
+| `vite.config.ts` | Vite config with workspace-package aliases |
+| `package.json` | Scripts and workspace dependencies |

--- a/example/vanilla-js/index.html
+++ b/example/vanilla-js/index.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>sw-editor — Vanilla JS Example</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 800px;
+        margin: 2rem auto;
+        padding: 0 1rem;
+        background: #f8f9fa;
+        color: #212529;
+      }
+      h1 { font-size: 1.4rem; margin-bottom: 0.5rem; }
+      p { color: #555; margin-top: 0; }
+      .card {
+        background: #fff;
+        border: 1px solid #dee2e6;
+        border-radius: 6px;
+        padding: 1rem 1.25rem;
+        margin-bottom: 1rem;
+      }
+      .card h2 { font-size: 1rem; margin: 0 0 0.5rem; }
+      pre {
+        background: #212529;
+        color: #f8f9fa;
+        padding: 0.75rem;
+        border-radius: 4px;
+        overflow-x: auto;
+        font-size: 0.85rem;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+      button {
+        background: #0d6efd;
+        color: #fff;
+        border: none;
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.9rem;
+      }
+      button:hover { background: #0b5ed7; }
+      button:disabled { background: #6c757d; cursor: not-allowed; }
+      .status { font-size: 0.85rem; color: #555; margin-top: 0.5rem; }
+      .status.ok { color: #198754; }
+      .status.error { color: #dc3545; }
+    </style>
+  </head>
+  <body>
+    <h1>sw-editor — Vanilla JS Integration</h1>
+    <p>
+      Demonstrates loading a Serverless Workflow fixture and exporting the
+      result using the host-client API.
+    </p>
+
+    <div class="card">
+      <h2>1. Load workflow from fixture</h2>
+      <button id="btn-load">Load simple.json fixture</button>
+      <p class="status" id="load-status">Not loaded yet.</p>
+    </div>
+
+    <div class="card">
+      <h2>2. Export workflow</h2>
+      <button id="btn-export" disabled>Export as JSON</button>
+      <button id="btn-export-yaml" disabled style="margin-left:0.5rem">Export as YAML</button>
+      <p class="status" id="export-status">Load a workflow first.</p>
+    </div>
+
+    <div class="card">
+      <h2>Exported output</h2>
+      <pre id="output">— no output yet —</pre>
+    </div>
+
+    <!--
+      In a full integration with a built editor bundle, add the component here:
+
+        <script type="module" src="/path/to/sw-editor.esm.js"></script>
+
+      Then embed the editor element:
+
+        <sw-editor id="editor" style="width:100%;height:400px;"></sw-editor>
+
+      And call the host contract methods on it:
+
+        const editor = document.getElementById('editor');
+        await editor.loadWorkflowSource({ source });
+        const result = await editor.exportWorkflowSource();
+    -->
+
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/example/vanilla-js/main.ts
+++ b/example/vanilla-js/main.ts
@@ -1,0 +1,118 @@
+/**
+ * Vanilla-JS host integration example for `@sw-editor/editor-host-client`.
+ *
+ * Demonstrates the load → export workflow:
+ *   1. Import a workflow fixture (JSON) bundled by Vite.
+ *   2. Pass it to `setCurrentSource` to register it as the active source.
+ *   3. Export it via `exportWorkflowSource` as JSON or YAML.
+ *
+ * In a complete integration the host application calls these operations
+ * through the `<sw-editor>` custom element, which owns parsing, graph
+ * projection, and visual rendering.  This example exercises the same
+ * host-client surface directly so it runs without requiring a built
+ * renderer bundle.
+ *
+ * No runtime external network calls are made — the fixture is bundled
+ * at build time by Vite.
+ *
+ * @module example/vanilla-js/main
+ */
+
+import { exportWorkflowSource, setCurrentSource } from "@sw-editor/editor-host-client";
+import type { WorkflowSource } from "@sw-editor/editor-host-client";
+
+// The fixture is bundled at build time — no runtime network call needed.
+import simpleWorkflow from "../../tests/fixtures/valid/simple.json";
+
+// ---------------------------------------------------------------------------
+// DOM refs
+// ---------------------------------------------------------------------------
+
+const btnLoad = document.getElementById("btn-load") as HTMLButtonElement;
+const btnExport = document.getElementById("btn-export") as HTMLButtonElement;
+const btnExportYaml = document.getElementById("btn-export-yaml") as HTMLButtonElement;
+const loadStatus = document.getElementById("load-status") as HTMLParagraphElement;
+const exportStatus = document.getElementById("export-status") as HTMLParagraphElement;
+const outputPre = document.getElementById("output") as HTMLPreElement;
+
+// ---------------------------------------------------------------------------
+// Event handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Stores the fixture as the current workflow source and enables the export
+ * buttons.
+ */
+btnLoad.addEventListener("click", () => {
+  try {
+    const content = JSON.stringify(simpleWorkflow, null, 2);
+    const source: WorkflowSource = { format: "json", content };
+
+    // Register the loaded source with the host-client so exportWorkflowSource
+    // can re-serialize it in the requested format.
+    setCurrentSource(source);
+
+    setStatus(loadStatus, "Workflow loaded successfully.", "ok");
+    btnExport.disabled = false;
+    btnExportYaml.disabled = false;
+    console.log("[sw-editor example] Loaded workflow source:", source);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    setStatus(loadStatus, `Error: ${message}`, "error");
+    console.error("[sw-editor example] Load failed:", err);
+  }
+});
+
+/**
+ * Exports the current workflow as JSON and renders it in the output pre-block.
+ */
+btnExport.addEventListener("click", async () => {
+  await runExport("json");
+});
+
+/**
+ * Exports the current workflow as YAML and renders it in the output pre-block.
+ */
+btnExportYaml.addEventListener("click", async () => {
+  await runExport("yaml");
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs an export in the specified format and updates the output area.
+ *
+ * @param format - Desired output format: `"json"` or `"yaml"`.
+ */
+async function runExport(format: "json" | "yaml"): Promise<void> {
+  setStatus(exportStatus, `Exporting as ${format.toUpperCase()}…`, "");
+
+  try {
+    const result = await exportWorkflowSource({ format });
+    outputPre.textContent = result.source.content;
+    setStatus(exportStatus, `Exported as ${format.toUpperCase()}.`, "ok");
+    console.log(`[sw-editor example] Exported (${format}):`, result.source.content);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    setStatus(exportStatus, `Export error: ${message}`, "error");
+    console.error("[sw-editor example] Export failed:", err);
+  }
+}
+
+/**
+ * Updates the text content and CSS class of a status paragraph.
+ *
+ * @param el - The status element to update.
+ * @param text - New text content.
+ * @param cssClass - CSS class to apply: `"ok"`, `"error"`, or `""` for neutral.
+ */
+function setStatus(
+  el: HTMLParagraphElement,
+  text: string,
+  cssClass: "ok" | "error" | "",
+): void {
+  el.textContent = text;
+  el.className = `status${cssClass ? ` ${cssClass}` : ""}`;
+}

--- a/example/vanilla-js/package.json
+++ b/example/vanilla-js/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@sw-editor/example-vanilla-js",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Vanilla-JS example: embed sw-editor, load a workflow fixture, and export the result",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@sw-editor/editor-host-client": "workspace:*",
+    "@sw-editor/editor-web-component": "workspace:*"
+  },
+  "devDependencies": {
+    "vite": "^6.0.0"
+  }
+}

--- a/example/vanilla-js/vite.config.ts
+++ b/example/vanilla-js/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+/**
+ * Vite configuration for the vanilla-js example.
+ *
+ * Resolves workspace packages from their TypeScript source so the example
+ * can be run with `pnpm dev` without a separate build step for each package.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@sw-editor/editor-host-client": resolve(
+        __dirname,
+        "../../packages/editor-host-client/src/index.ts",
+      ),
+      "@sw-editor/editor-core": resolve(
+        __dirname,
+        "../../packages/editor-core/src/index.ts",
+      ),
+    },
+  },
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,5 @@ packages:
   - "packages/editor-renderer-contract"
   - "packages/editor-renderer-rete-lit"
   - "packages/editor-renderer-react-flow"
+  - "example/vanilla-js"
+  - "example/host-events"


### PR DESCRIPTION
## Summary

- Adds `example/vanilla-js/` — a Vite-based page demonstrating loading a workflow fixture and exporting it as JSON/YAML via the host-client API.
- Adds `example/host-events/` — a Vite-based page demonstrating subscription to all four editor contract events and rendering a capability snapshot.
- Updates `pnpm-workspace.yaml` to register both example packages.

## Details

### `example/vanilla-js/`

- Imports `tests/fixtures/valid/simple.json` at build time (no runtime network call).
- Calls `setCurrentSource` and `exportWorkflowSource` from `@sw-editor/editor-host-client`.
- Includes comments showing how to wire `<sw-editor>` once a built bundle is available.
- Start: `pnpm --filter @sw-editor/example-vanilla-js dev`

### `example/host-events/`

- Creates an `EventBridge` on a plain `EventTarget` to simulate editor events.
- Subscribes to `workflowChanged`, `editorDiagnosticsChanged`, `editorSelectionChanged`, `editorError`.
- Displays received events in a live log and populates a renderer capabilities table.
- Start: `pnpm --filter @sw-editor/example-host-events dev`

Both examples:
- Use Vite aliases to resolve workspace TypeScript packages without a prior build step.
- Make **no runtime external network calls** (constitution requirement satisfied).
- Are self-contained and startable with a single documented command.

## Test plan

- [ ] `pnpm install` from repo root completes without error
- [ ] `pnpm --filter @sw-editor/example-vanilla-js dev` starts Vite dev server
- [ ] Clicking "Load simple.json fixture" shows success status
- [ ] Clicking "Export as JSON" / "Export as YAML" renders workflow in output panel
- [ ] `pnpm --filter @sw-editor/example-host-events dev` starts Vite dev server
- [ ] Each simulation button appends an entry to the event log
- [ ] "Query capabilities" populates the capabilities table

Closes #98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)