### PR TITLE
docs(specs): final sync — tasks.md, specs/README.md, acceptance coverage (#100)

### DIFF
--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -74,3 +74,39 @@
 - [ ] T034 [OUT-OF-SCOPE #106] Create demo HTML harness and add `webServer` to `playwright.config.ts` to automate Playwright e2e (GAP-001 / F001 — SC-001, SC-007)
 - [ ] T035 [OUT-OF-SCOPE #107] Add `tests/e2e/quickstart-scenarios.spec.ts` Playwright counterpart for quickstart scenarios (Finding F002)
 - [ ] T036 [OUT-OF-SCOPE #108] Add package-level unit tests for `packages/editor-host-client/` (Finding F003)
+
+## Phase 8: Example Applications (Phase C)
+
+**Goal**: Provide runnable integration examples demonstrating host-client embedding patterns.
+
+- [x] T037 Add `example/vanilla-js/` integration demo: load/export workflow via host-client API (`example/vanilla-js/index.html`, `main.ts`, `vite.config.ts`, `package.json`)
+- [x] T038 Add `example/host-events/` integration demo: event subscription and capability query patterns (`example/host-events/index.html`, `main.ts`, `vite.config.ts`, `package.json`)
+- [x] T039 Add `example/README.md` documenting both example apps and how to run them
+- [x] T040 Add `example/playwright.config.ts` with `webServer` entries for `vanilla-js` (port 5174) and `host-events` (port 5175)
+
+## Phase 9: Example Playwright E2E Coverage (Phase D)
+
+**Goal**: Automate acceptance verification for both example apps using Playwright.
+
+- [x] T041 Add `example/tests/vanilla-js.spec.ts` — Playwright e2e tests covering page load, workflow load, and JSON/YAML export flows (US2 Scenario 2, SC-003)
+- [x] T042 Add `example/tests/host-events.spec.ts` — Playwright e2e tests covering diagnostics events, capability query, and clear-log flows (US3 Scenario 2, SC-002)
+
+## Phase 10: Final Sync (Task #100)
+
+**Goal**: Confirm complete acceptance coverage and update all spec artifacts.
+
+- [x] T043 Update `specs/001-visual-authoring-mvp/tasks.md` with all Phase 8–9 entries and confirm `[x]`/`[ ]` state for all tasks
+- [x] T044 Update `specs/README.md` to reflect example directory and current test coverage status
+- [x] T045 Map every acceptance scenario in `spec.md` to at least one automated test (see coverage table below)
+
+### Acceptance Scenario Coverage
+
+| Scenario | Test File(s) |
+|----------|-------------|
+| US1-S1: new workflow → start/end nodes | `tests/integration/quickstart-scenarios.spec.ts` (Scenario 1); `tests/e2e/accessibility-mvp.spec.ts` (new-workflow keyboard tests) |
+| US1-S2: insertion affordance → task inserted between nodes | `tests/integration/quickstart-scenarios.spec.ts` (Scenario 2); `tests/e2e/accessibility-mvp.spec.ts` (task insertion keyboard tests) |
+| US1-S3: edit task properties → workflow source updated | `tests/integration/quickstart-scenarios.spec.ts` (Scenario 2 — revision tracking); `tests/integration/workflow-roundtrip.spec.ts` |
+| US2-S1: load JSON/YAML → graph and panel reflect structure | `tests/integration/quickstart-scenarios.spec.ts` (Scenario 3); `tests/integration/workflow-roundtrip.spec.ts` |
+| US2-S2: visual edits → export returns updated source | `tests/integration/workflow-roundtrip.spec.ts`; `example/tests/vanilla-js.spec.ts` (export as JSON/YAML) |
+| US3-S1: invalid input → debounce → diagnostics update | `tests/integration/quickstart-scenarios.spec.ts` (Scenario 4); `tests/contract/editor-diagnostics.contract.spec.ts` |
+| US3-S2: explicit validation → full diagnostics emitted | `tests/integration/quickstart-scenarios.spec.ts` (Scenario 4 — full validator); `tests/contract/editor-diagnostics.contract.spec.ts` |

--- a/specs/README.md
+++ b/specs/README.md
@@ -4,12 +4,12 @@ This repository now uses GitHub Spec Kit feature packages under `specs/`.
 
 ## Feature Set
 
-| Feature | One-Line Summary |
-|---------|-----------------|
-| [`001-visual-authoring-mvp`](001-visual-authoring-mvp/) | Embeddable visual authoring for Serverless Workflow with source round-trip, insertion UX, and live diagnostics. |
-| [`002-nested-tasks-ux`](002-nested-tasks-ux/) | Visual authoring support for nested task structures with expanded default rendering. |
-| [`003-branching-control-flow`](003-branching-control-flow/) | Panel-driven authoring for transition, if, switch, fork, and try-catch behavior with route projection. |
-| [`004-extensibility-customization`](004-extensibility-customization/) | Plugin architecture for custom rendering, validation, commands, and slot-based UI extensions. |
+| Feature | Status | One-Line Summary |
+|---------|--------|-----------------|
+| [`001-visual-authoring-mvp`](001-visual-authoring-mvp/) | Implementation complete | Embeddable visual authoring for Serverless Workflow with source round-trip, insertion UX, live diagnostics, and runnable example apps. |
+| [`002-nested-tasks-ux`](002-nested-tasks-ux/) | Planned | Visual authoring support for nested task structures with expanded default rendering. |
+| [`003-branching-control-flow`](003-branching-control-flow/) | Planned | Panel-driven authoring for transition, if, switch, fork, and try-catch behavior with route projection. |
+| [`004-extensibility-customization`](004-extensibility-customization/) | Planned | Plugin architecture for custom rendering, validation, commands, and slot-based UI extensions. |
 
 Each feature package contains:
 
@@ -23,3 +23,29 @@ Each feature package contains:
 
 Rendering strategy note:
 - Visual authoring specs now target two renderer backends (`rete-lit` and `react-flow`) with parity and comparison criteria to support evidence-based renderer selection.
+
+## Feature 001 — Test Coverage Summary
+
+All seven acceptance scenarios in `spec.md` are covered by automated tests.
+
+| Layer | Test Files |
+|-------|-----------|
+| Unit / integration (vitest) | `tests/integration/quickstart-scenarios.spec.ts`, `tests/integration/workflow-roundtrip.spec.ts`, `tests/integration/validation-latency.spec.ts`, `tests/integration/renderer-mvp-parity.spec.ts` |
+| Contract (vitest) | `tests/contract/editor-diagnostics.contract.spec.ts`, `tests/contract/renderer-capabilities.contract.spec.ts` |
+| E2E accessibility (Playwright) | `tests/e2e/accessibility-mvp.spec.ts` |
+| E2E example apps (Playwright) | `example/tests/vanilla-js.spec.ts`, `example/tests/host-events.spec.ts` |
+
+### Example Applications
+
+Two runnable integration demos live under `example/`:
+
+- **`example/vanilla-js/`** — load/export workflow via host-client API; run with `pnpm exec vite --port 5174` inside that directory.
+- **`example/host-events/`** — event subscription and capability query patterns; run with `pnpm exec vite --port 5175` inside that directory.
+
+Run the full example Playwright suite from the repo root:
+
+```sh
+pnpm test:examples
+# or
+pnpm exec playwright test --config example/playwright.config.ts
+```


### PR DESCRIPTION
## Summary

- Added **Phase 8** entries (T037–T040) to `tasks.md` for the `example/vanilla-js` and `example/host-events` apps created in #105.
- Added **Phase 9** entries (T041–T042) for the Playwright e2e tests in `example/tests/` added in #110.
- Added **Phase 10** entries (T043–T045) for this final sync task, including a full acceptance scenario coverage table.
- Updated `specs/README.md` with a Status column, test coverage summary by layer, and example app run instructions.

## Acceptance Coverage

Every acceptance scenario in `spec.md` maps to at least one automated test (see coverage table in `tasks.md` Phase 10).

## Test plan

- [x] `pnpm exec vitest run` — 356 tests across 17 files, all passing
- [x] `pnpm test` — exits 0 (all package-level vitest suites pass)
- [x] Playwright example suite available via `pnpm test:examples` (requires Vite dev servers)

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)