### PR TITLE
test(editor-host-client): add unit tests for capabilities.ts

### DIFF
--- a/packages/editor-host-client/tests/capabilities.spec.ts
+++ b/packages/editor-host-client/tests/capabilities.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for `src/contracts/capabilities.ts`.
+ *
+ * Covers the static metadata constants and the `createCapabilitySnapshot`
+ * pure factory function. No renderer adapters or DOM stubs are required.
+ *
+ * @module
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CONTRACT_VERSION,
+  SUPPORTED_VERSIONS,
+  TARGET_VERSION,
+  createCapabilitySnapshot,
+} from "../src/contracts/capabilities.js";
+import type { RendererCapabilitySnapshot } from "../src/contracts/capabilities.js";
+
+// ---------------------------------------------------------------------------
+// Shared test fixture — a minimal RendererCapabilitySnapshot for a rete-lit renderer.
+// ---------------------------------------------------------------------------
+
+const reteLitCaps: RendererCapabilitySnapshot = {
+  rendererId: "rete-lit",
+  rendererVersion: "1.0.0",
+  supportsNodeRendererPlugins: true,
+  supportsNestedInlineProjection: false,
+  supportsRouteOverlayProjection: false,
+};
+
+const reactFlowCaps: RendererCapabilitySnapshot = {
+  rendererId: "react-flow",
+  rendererVersion: "12.0.0",
+  supportsNodeRendererPlugins: true,
+  supportsNestedInlineProjection: false,
+  supportsRouteOverlayProjection: false,
+};
+
+// ---------------------------------------------------------------------------
+// Metadata constants
+// ---------------------------------------------------------------------------
+
+describe("metadata constants", () => {
+  it("CONTRACT_VERSION is defined and non-empty", () => {
+    expect(CONTRACT_VERSION).toBeDefined();
+    expect(typeof CONTRACT_VERSION).toBe("string");
+    expect(CONTRACT_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it("TARGET_VERSION is defined and non-empty", () => {
+    expect(TARGET_VERSION).toBeDefined();
+    expect(typeof TARGET_VERSION).toBe("string");
+    expect(TARGET_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it("SUPPORTED_VERSIONS is defined and non-empty", () => {
+    expect(SUPPORTED_VERSIONS).toBeDefined();
+    expect(Array.isArray(SUPPORTED_VERSIONS)).toBe(true);
+    expect(SUPPORTED_VERSIONS.length).toBeGreaterThan(0);
+  });
+
+  it("SUPPORTED_VERSIONS includes TARGET_VERSION", () => {
+    expect(SUPPORTED_VERSIONS).toContain(TARGET_VERSION);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCapabilitySnapshot factory
+// ---------------------------------------------------------------------------
+
+describe("createCapabilitySnapshot", () => {
+  it("sets contractVersion equal to CONTRACT_VERSION", () => {
+    const snapshot = createCapabilitySnapshot(reteLitCaps);
+    expect(snapshot.contractVersion).toBe(CONTRACT_VERSION);
+  });
+
+  it("sets targetVersion equal to TARGET_VERSION", () => {
+    const snapshot = createCapabilitySnapshot(reteLitCaps);
+    expect(snapshot.targetVersion).toBe(TARGET_VERSION);
+  });
+
+  it("sets supportedVersions equal to SUPPORTED_VERSIONS content", () => {
+    const snapshot = createCapabilitySnapshot(reteLitCaps);
+    expect(snapshot.supportedVersions).toEqual([...SUPPORTED_VERSIONS]);
+  });
+
+  it("copies rendererId from the renderer capabilities", () => {
+    const snapshot = createCapabilitySnapshot(reteLitCaps);
+    expect(snapshot.rendererId).toBe(reteLitCaps.rendererId);
+  });
+
+  it("embeds the renderer capabilities object as-is", () => {
+    const snapshot = createCapabilitySnapshot(reteLitCaps);
+    expect(snapshot.rendererCapabilities).toBe(reteLitCaps);
+  });
+
+  it("returns correct rendererId for react-flow renderer caps", () => {
+    const snapshot = createCapabilitySnapshot(reactFlowCaps);
+    expect(snapshot.rendererId).toBe("react-flow");
+  });
+
+  it("supportedVersions is a fresh array copy, not the same reference as SUPPORTED_VERSIONS", () => {
+    const snapshot = createCapabilitySnapshot(reteLitCaps);
+    expect(snapshot.supportedVersions).not.toBe(SUPPORTED_VERSIONS);
+  });
+});


### PR DESCRIPTION
## Summary

- Creates `packages/editor-host-client/tests/capabilities.spec.ts` with 11 unit tests covering `src/contracts/capabilities.ts`
- Tests verify `CONTRACT_VERSION`, `TARGET_VERSION`, `SUPPORTED_VERSIONS` constants are defined and non-empty
- Tests verify `SUPPORTED_VERSIONS` contains `TARGET_VERSION`
- Tests verify `createCapabilitySnapshot` sets correct `contractVersion`, `targetVersion`, `supportedVersions`, `rendererId`, and `rendererCapabilities`
- Tests verify `supportedVersions` is a fresh array copy (not the same reference as `SUPPORTED_VERSIONS`)
- No renderer adapters or DOM stubs required (pure function tests only)

## Test plan

- [x] All 11 test cases pass via `pnpm vitest run --project editor-host-client`

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)