### PR TITLE
chore(specs): verify ≥10 passing tests and root contract tests (closes #118)

### DIFF
--- a/specs/001-visual-authoring-mvp/tasks.md
+++ b/specs/001-visual-authoring-mvp/tasks.md
@@ -73,7 +73,7 @@
 - [x] T033 Document and triage all gaps from audit tasks #94, #95, #96; file out-of-scope items as child issues
 - [ ] T034 [OUT-OF-SCOPE #106] Create demo HTML harness and add `webServer` to `playwright.config.ts` to automate Playwright e2e (GAP-001 / F001 — SC-001, SC-007)
 - [ ] T035 [OUT-OF-SCOPE #107] Add `tests/e2e/quickstart-scenarios.spec.ts` Playwright counterpart for quickstart scenarios (Finding F002)
-- [ ] T036 [OUT-OF-SCOPE #108] Add package-level unit tests for `packages/editor-host-client/` (Finding F003)
+- [x] T036 [OUT-OF-SCOPE #108] Add package-level unit tests for `packages/editor-host-client/` (Finding F003) — 59 tests passing across capabilities.spec.ts, methods.spec.ts, export.spec.ts (#133, #134, #135)
 
 ## Phase 8: Example Applications (Phase C)
 


### PR DESCRIPTION
## Summary

Verification task confirming all acceptance criteria for #118 are met.

- **Package tests** (`pnpm --filter @sw-editor/editor-host-client test`): **59 tests passing** across 3 spec files — well above the ≥10 threshold.
  - `tests/capabilities.spec.ts`: 11 tests ✓
  - `tests/methods.spec.ts`: 27 tests ✓
  - `tests/export.spec.ts`: 21 tests ✓
- **Root contract tests** (`vitest run tests/contract/renderer-capabilities.contract.spec.ts`): **32 tests passing**, no modifications required.

No code changes were needed. This PR also marks `T036` as complete in `tasks.md` since the unit tests were added in PRs #133–#135.

Closes #118