### PR TITLE
feat(demo): add demo/package.json

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@sw-editor/demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --port 4173"
+  },
+  "dependencies": {
+    "@sw-editor/editor-host-client": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,4 @@ packages:
   - "packages/editor-renderer-react-flow"
   - "example/vanilla-js"
   - "example/host-events"
+  - "demo"


### PR DESCRIPTION
## Summary
- Creates `demo/package.json` as the package descriptor for the demo/harness app
- Name: `@sw-editor/demo` (private: true)
- Scripts: `dev`, `build`, `vite preview --port 4173`
- Dependency: workspace reference to `@sw-editor/editor-host-client`
- DevDependencies: `vite ^6.0.0`, `typescript 5.9.3`
- Registers `demo` in `pnpm-workspace.yaml`

Closes #119

## Test plan
- [ ] `demo/package.json` exists with correct name, scripts, and workspace dependency reference
- [ ] `pnpm-workspace.yaml` includes `"demo"` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)