### PR TITLE
feat(demo): add vite.config.ts with workspace alias and port 4173

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+/**
+ * Vite configuration for the demo harness app.
+ *
+ * Resolves workspace packages from their TypeScript source so the demo
+ * can be run with `pnpm dev` without a separate build step for each package.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@sw-editor/editor-host-client": resolve(
+        __dirname,
+        "../packages/editor-host-client/src/index.ts",
+      ),
+    },
+  },
+  build: {
+    outDir: "dist",
+  },
+  server: {
+    port: 4173,
+  },
+  preview: {
+    port: 4173,
+  },
+});


### PR DESCRIPTION
## Summary

- Creates `demo/vite.config.ts` following the same alias resolution pattern as `example/vanilla-js/vite.config.ts`
- Resolves `@sw-editor/editor-host-client` from TypeScript source (`../packages/editor-host-client/src/index.ts`)
- Sets `build.outDir` to `dist/`
- Pins `server.port` and `preview.port` to `4173`

Closes #120

## Test plan

- [ ] Run `pnpm --filter @sw-editor/demo dev` — dev server starts on port 4173
- [ ] Run `pnpm --filter @sw-editor/demo build` — output lands in `demo/dist/`
- [ ] Run `pnpm --filter @sw-editor/demo preview` — preview serves on port 4173

🤖 Generated with [Claude Code](https://claude.com/claude-code)