### PR TITLE
feat(demo): create demo/index.html entry point with ARIA landmarks

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>sw-editor — Demo Harness</title>
+    <style>
+      * { box-sizing: border-box; margin: 0; padding: 0; }
+      body { display: flex; flex-direction: column; height: 100vh; font-family: system-ui, sans-serif; }
+      main { flex: 1; display: flex; overflow: hidden; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <sw-editor id="editor" style="width:100%;height:600px;"></sw-editor>
+
+      <!-- Properties panel region — required by accessibility tests -->
+      <aside role="region" aria-label="Properties panel"></aside>
+
+      <!-- ARIA live region for screen-reader announcements -->
+      <div aria-live="polite" aria-atomic="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;"></div>
+    </main>
+
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Creates `demo/index.html` as the entry point for the demo harness app
- Includes `<sw-editor id="editor" style="width:100%;height:600px;"></sw-editor>` in the body
- Adds required ARIA landmarks: `<main>`, properties panel region (`role="region" aria-label="Properties panel"`), and ARIA live region (`aria-live="polite"`)
- Loads `./main.ts` as a module script

## Test plan

- [ ] Verify `demo/index.html` exists with `sw-editor` element
- [ ] Verify `<main>` landmark is present
- [ ] Verify `[aria-label="Properties panel"]` region is present
- [ ] Verify `[aria-live]` element is present
- [ ] Verify `<script type="module" src="./main.ts">` is included

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)