### PR TITLE
feat(e2e): add webServer block to playwright.config.ts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,4 +26,10 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
+  webServer: {
+    command:
+      "pnpm --filter @sw-editor/demo build && pnpm --filter @sw-editor/demo preview",
+    url: "http://localhost:4173",
+    reuseExistingServer: !process.env.CI,
+  },
 });


### PR DESCRIPTION
## Summary

- Adds a `webServer` block to `playwright.config.ts` so `pnpm test:e2e` auto-starts the demo server before running tests.
- Uses `pnpm --filter @sw-editor/demo build && pnpm --filter @sw-editor/demo preview` as the command.
- Sets `url: 'http://localhost:4173'` and `reuseExistingServer: !process.env.CI`.
- All existing `use`, `projects`, and `testDir` config is preserved.

Closes #123

## Test plan

- [ ] Run `pnpm test:e2e` locally — verify the demo server starts automatically and tests execute against it.
- [ ] Confirm `reuseExistingServer` skips re-launch when a server is already running (local dev).
- [ ] On CI (`CI=1`), confirm a fresh server is always started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)