### PR TITLE
chore(workspace): resolve @sw-editor/demo as workspace package

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,19 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@types/node@25.3.3)(happy-dom@20.8.3)
 
+  demo:
+    dependencies:
+      '@sw-editor/editor-host-client':
+        specifier: workspace:*
+        version: link:../packages/editor-host-client
+    devDependencies:
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@25.3.3)
+
   example/host-events:
     dependencies:
       '@sw-editor/editor-host-client':


### PR DESCRIPTION
## Summary

- `demo` was already listed in `pnpm-workspace.yaml` (added in #138)
- Ran `pnpm install` to update `pnpm-lock.yaml` so the lockfile records `@sw-editor/demo` and its dependencies as a workspace package
- `@sw-editor/demo@0.0.0` now resolves correctly via `pnpm list --filter @sw-editor/demo`

Closes #125

## Test plan

- [x] `demo` listed under `packages` in `pnpm-workspace.yaml`
- [x] `pnpm install` completes without errors (10 workspace projects resolved)
- [x] `pnpm list --filter @sw-editor/demo` shows `@sw-editor/demo@0.0.0` with workspace link dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)