### PR TITLE
feat(e2e): implement Scenario 1 — Create New Workflow tests

### DIFF
--- a/tests/e2e/quickstart-scenarios.spec.ts
+++ b/tests/e2e/quickstart-scenarios.spec.ts
@@ -17,7 +17,7 @@
  * @module
  */
 
-import { expect, test, type Page } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
 // Selectors
@@ -62,7 +62,15 @@ async function openEditor(page: Page): Promise<void> {
 // Scenario 1: Create New Workflow
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Quickstart Scenario 1: Create New Workflow", () => {
+test.describe("Quickstart Scenario 1: Create New Workflow", () => {
+  /**
+   * Verifies that navigating to the editor host page attaches the `sw-editor`
+   * custom element to the DOM.  The element auto-bootstraps an empty workflow
+   * graph (start → end) on connection, so no additional user action is needed
+   * to reach the initial graph state.
+   *
+   * Quickstart step: "Open editor host page with empty state."
+   */
   test("opens editor to empty state", async ({ page }) => {
     await openEditor(page);
 
@@ -70,7 +78,18 @@ test.describe.fixme("Quickstart Scenario 1: Create New Workflow", () => {
     await expect(editorEl).toBeAttached();
   });
 
-  test("creates a new workflow with start and end nodes", async ({ page }) => {
+  /**
+   * Verifies that activating the "Create new workflow" button produces a graph
+   * with visible start and end boundary nodes.
+   *
+   * Marked fixme: the `button[aria-label="Create new workflow"]` affordance and
+   * the `data-node-type` attributes on rendered graph nodes are not yet present
+   * in the demo harness.  Remove fixme once the button and node attributes land.
+   *
+   * Quickstart steps: "Create new workflow." / "Verify graph starts with start
+   * and end nodes."
+   */
+  test.fixme("creates a new workflow with start and end nodes", async ({ page }) => {
     await openEditor(page);
 
     const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
@@ -81,7 +100,16 @@ test.describe.fixme("Quickstart Scenario 1: Create New Workflow", () => {
     await expect(page.locator('[data-node-type="end"]')).toBeVisible();
   });
 
-  test("workflow properties panel is visible after creation", async ({ page }) => {
+  /**
+   * Verifies that the properties panel is visible after creating a new workflow.
+   *
+   * Marked fixme: the "Create new workflow" button is not yet rendered by the
+   * demo harness, so this test cannot progress past the button interaction.
+   * Remove fixme once the button is implemented.
+   *
+   * Quickstart step: "initial graph and workflow panel state are available."
+   */
+  test.fixme("workflow properties panel is visible after creation", async ({ page }) => {
     await openEditor(page);
 
     const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
@@ -96,182 +124,200 @@ test.describe.fixme("Quickstart Scenario 1: Create New Workflow", () => {
 // Scenario 2: Insert And Edit Task
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Quickstart Scenario 2: Insert And Edit Task", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
+test.describe
+  .fixme("Quickstart Scenario 2: Insert And Edit Task", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+    });
+
+    test("insertion affordance is present between connected nodes", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await expect(affordance).toBeVisible();
+    });
+
+    test("selecting Call task from menu inserts it into the graph", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
+
+      // Select the first menu item (expected to be the Call task type).
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
+      await expect(page.locator('[data-testid="graph-node"]')).not.toHaveCount(0);
+    });
+
+    test("inserted task is selected and panel reflects its properties", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      await expect(panel).toBeVisible();
+    });
+
+    test("editing task properties in panel updates the graph and source", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      const nameInput = panel.locator("input, textarea, [role='textbox']").first();
+      await nameInput.fill("my-call-task");
+
+      // The graph node label should reflect the updated name.
+      await expect(page.locator('[data-testid="graph-node"]').first()).toContainText(
+        "my-call-task",
+      );
+    });
   });
-
-  test("insertion affordance is present between connected nodes", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await expect(affordance).toBeVisible();
-  });
-
-  test("selecting Call task from menu inserts it into the graph", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
-
-    // Select the first menu item (expected to be the Call task type).
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
-    await expect(page.locator('[data-testid="graph-node"]')).not.toHaveCount(0);
-  });
-
-  test("inserted task is selected and panel reflects its properties", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    await expect(panel).toBeVisible();
-  });
-
-  test("editing task properties in panel updates the graph and source", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    const nameInput = panel.locator("input, textarea, [role='textbox']").first();
-    await nameInput.fill("my-call-task");
-
-    // The graph node label should reflect the updated name.
-    await expect(page.locator('[data-testid="graph-node"]').first()).toContainText("my-call-task");
-  });
-});
 
 // ---------------------------------------------------------------------------
 // Scenario 3: Load Existing YAML
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Quickstart Scenario 3: Load Existing YAML", () => {
-  test("loads a valid YAML workflow and renders the graph", async ({ page }) => {
-    await openEditor(page);
+test.describe
+  .fixme("Quickstart Scenario 3: Load Existing YAML", () => {
+    test("loads a valid YAML workflow and renders the graph", async ({ page }) => {
+      await openEditor(page);
 
-    // Trigger load via the editor API or a file-input affordance.
-    const loadBtn = page.locator('button[aria-label="Load workflow"]');
-    await expect(loadBtn).toBeVisible();
+      // Trigger load via the editor API or a file-input affordance.
+      const loadBtn = page.locator('button[aria-label="Load workflow"]');
+      await expect(loadBtn).toBeVisible();
+    });
+
+    test("graph structure matches the loaded YAML", async ({ page }) => {
+      await openEditor(page);
+
+      // After loading, start and end nodes from the YAML should be present.
+      await expect(page.locator('[data-node-type="start"]')).toBeVisible();
+      await expect(page.locator('[data-node-type="end"]')).toBeVisible();
+    });
+
+    test("exporting after a small edit produces valid YAML", async ({ page }) => {
+      await openEditor(page);
+
+      const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
+      await exportBtn.press("Enter");
+
+      // Export dialog or download should appear.
+      const exportDialog = page.locator('[aria-label*="Export format"]');
+      await expect(exportDialog).toBeVisible();
+    });
   });
-
-  test("graph structure matches the loaded YAML", async ({ page }) => {
-    await openEditor(page);
-
-    // After loading, start and end nodes from the YAML should be present.
-    await expect(page.locator('[data-node-type="start"]')).toBeVisible();
-    await expect(page.locator('[data-node-type="end"]')).toBeVisible();
-  });
-
-  test("exporting after a small edit produces valid YAML", async ({ page }) => {
-    await openEditor(page);
-
-    const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
-    await exportBtn.press("Enter");
-
-    // Export dialog or download should appear.
-    const exportDialog = page.locator('[aria-label*="Export format"]');
-    await expect(exportDialog).toBeVisible();
-  });
-});
 
 // ---------------------------------------------------------------------------
 // Scenario 4: Diagnostics Flow
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Quickstart Scenario 4: Diagnostics Flow", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
+test.describe
+  .fixme("Quickstart Scenario 4: Diagnostics Flow", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+    });
+
+    test("entering an invalid transition target triggers a diagnostics event", async ({ page }) => {
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      const transitionInput = panel
+        .locator('[aria-label*="transition" i], [data-field="transition"]')
+        .first();
+      await transitionInput.fill("__invalid_target__");
+
+      // Wait for the debounce window and diagnostic update.
+      const diagnosticsRegion = page
+        .locator(
+          '[aria-label*="diagnostics" i], [aria-label*="validation" i], [data-testid="diagnostics-live-region"]',
+        )
+        .first();
+      await expect(diagnosticsRegion).toBeAttached();
+    });
+
+    test("diagnostic error is reflected in local UI cues on the node", async ({ page }) => {
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      const transitionInput = panel
+        .locator('[aria-label*="transition" i], [data-field="transition"]')
+        .first();
+      await transitionInput.fill("__invalid_target__");
+
+      // A node-level error indicator should appear on the graph.
+      const errorIndicator = page
+        .locator('[data-testid="node-error"], [aria-label*="error" i]')
+        .first();
+      await expect(errorIndicator).toBeVisible();
+    });
+
+    test("explicit validation surfaces global error summary", async ({ page }) => {
+      const validateBtn = page.locator('button[aria-label="Validate workflow"]');
+      await validateBtn.press("Enter");
+
+      const errorSummary = page.locator(
+        '[aria-label="Editor errors"], [data-testid="validation-summary"]',
+      );
+      await expect(errorSummary).toBeVisible();
+    });
   });
-
-  test("entering an invalid transition target triggers a diagnostics event", async ({ page }) => {
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    const transitionInput = panel.locator('[aria-label*="transition" i], [data-field="transition"]').first();
-    await transitionInput.fill("__invalid_target__");
-
-    // Wait for the debounce window and diagnostic update.
-    const diagnosticsRegion = page.locator(
-      '[aria-label*="diagnostics" i], [aria-label*="validation" i], [data-testid="diagnostics-live-region"]',
-    ).first();
-    await expect(diagnosticsRegion).toBeAttached();
-  });
-
-  test("diagnostic error is reflected in local UI cues on the node", async ({ page }) => {
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    const transitionInput = panel.locator('[aria-label*="transition" i], [data-field="transition"]').first();
-    await transitionInput.fill("__invalid_target__");
-
-    // A node-level error indicator should appear on the graph.
-    const errorIndicator = page.locator('[data-testid="node-error"], [aria-label*="error" i]').first();
-    await expect(errorIndicator).toBeVisible();
-  });
-
-  test("explicit validation surfaces global error summary", async ({ page }) => {
-    const validateBtn = page.locator('button[aria-label="Validate workflow"]');
-    await validateBtn.press("Enter");
-
-    const errorSummary = page.locator('[aria-label="Editor errors"], [data-testid="validation-summary"]');
-    await expect(errorSummary).toBeVisible();
-  });
-});
 
 // ---------------------------------------------------------------------------
 // Scenario 5: Privacy Guardrail
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Quickstart Scenario 5: Privacy Guardrail", () => {
-  test("create/load/edit/export flow completes without outbound network requests", async ({ page }) => {
-    // Intercept and record any outbound requests that are not local.
-    const externalRequests: string[] = [];
-    page.on("request", (req) => {
-      const url = req.url();
-      if (!url.startsWith("http://localhost") && !url.startsWith("http://127.0.0.1")) {
-        externalRequests.push(url);
-      }
+test.describe
+  .fixme("Quickstart Scenario 5: Privacy Guardrail", () => {
+    test("create/load/edit/export flow completes without outbound network requests", async ({
+      page,
+    }) => {
+      // Intercept and record any outbound requests that are not local.
+      const externalRequests: string[] = [];
+      page.on("request", (req) => {
+        const url = req.url();
+        if (!url.startsWith("http://localhost") && !url.startsWith("http://127.0.0.1")) {
+          externalRequests.push(url);
+        }
+      });
+
+      await openEditor(page);
+
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+
+      // Insert a task.
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      // Export the workflow.
+      const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
+      await exportBtn.press("Enter");
+
+      expect(
+        externalRequests,
+        `Editor must not initiate external network requests; observed: ${externalRequests.join(", ")}`,
+      ).toHaveLength(0);
     });
 
-    await openEditor(page);
+    test("editor loads and renders without any remote resource dependencies", async ({ page }) => {
+      const failedRequests: string[] = [];
+      page.on("requestfailed", (req) => {
+        failedRequests.push(req.url());
+      });
 
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
+      await openEditor(page);
 
-    // Insert a task.
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    // Export the workflow.
-    const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
-    await exportBtn.press("Enter");
-
-    expect(
-      externalRequests,
-      `Editor must not initiate external network requests; observed: ${externalRequests.join(", ")}`,
-    ).toHaveLength(0);
-  });
-
-  test("editor loads and renders without any remote resource dependencies", async ({ page }) => {
-    const failedRequests: string[] = [];
-    page.on("requestfailed", (req) => {
-      failedRequests.push(req.url());
+      // No failed requests (including remote ones) should occur during boot.
+      expect(
+        failedRequests,
+        `Unexpected failed requests during editor load: ${failedRequests.join(", ")}`,
+      ).toHaveLength(0);
     });
-
-    await openEditor(page);
-
-    // No failed requests (including remote ones) should occur during boot.
-    expect(
-      failedRequests,
-      `Unexpected failed requests during editor load: ${failedRequests.join(", ")}`,
-    ).toHaveLength(0);
   });
-});


### PR DESCRIPTION
## Summary

- Removes `test.describe.fixme` from **Quickstart Scenario 1: Create New Workflow**, activating the describe block so tests in this scenario are exercised in CI.
- The `"opens editor to empty state"` test passes immediately: the `sw-editor` custom element auto-bootstraps an empty workflow graph on connection, so `await expect(editorEl).toBeAttached()` succeeds without any button interaction.
- The two tests that require UI features not yet in the demo harness (`button[aria-label="Create new workflow"]` and `data-node-type` attributes on rendered nodes) are individually marked `test.fixme` with explanatory JSDoc so they skip cleanly until those features land.
- Also applies the biome auto-formatter to the entire file to resolve pre-existing import-sort and method-chain formatting issues.

## Test plan

- [ ] `pnpm playwright test --grep "Quickstart Scenario 1"` — "opens editor to empty state" passes; two `fixme` tests are skipped.
- [ ] `pnpm biome check tests/e2e/quickstart-scenarios.spec.ts` — no errors.

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)