### PR TITLE
chore: Phase 2 — rename package @sw-editor/demo to @sw-editor/example-e2e-harness

### DIFF
--- a/specs/005-align-example-demo/spec.md
+++ b/specs/005-align-example-demo/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `005-align-example-demo`
 **Created**: 2026-03-06
-**Status**: Draft
+**Status**: Implemented
 **Input**: User description: "Align example and demo directories. The repo has two directories illustrating library usage: `demo/` (package `@sw-editor/demo`, a Vite app with the custom sw-editor element and e2e harness) and `example/` (contains `vanilla-js/`, `host-events/` sub-apps and Playwright tests in `tests/`). The decision is: keep `example/` as the top-level directory name; rename `demo/` to `example/e2e-harness/` with package name `@sw-editor/example-e2e-harness`. Feature number is 005."
 
 ---


### PR DESCRIPTION
## Summary

- All acceptance criteria for #155 were already satisfied by Phase 1 (commit `a462743`, #163)
- `example/e2e-harness/package.json` `"name"` is `"@sw-editor/example-e2e-harness"` ✅
- No `package.json` files in the workspace reference `@sw-editor/demo` ✅
- No internal scripts reference `@sw-editor/demo` ✅
- Updated `specs/005-align-example-demo/spec.md` status from `Draft` → `Implemented`

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)