### PR TITLE
chore: update pnpm lockfile for example/e2e-harness workspace entry

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,14 +21,14 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@types/node@25.3.3)(happy-dom@20.8.3)
 
-  demo:
+  example/e2e-harness:
     dependencies:
       '@sw-editor/editor-core':
         specifier: workspace:*
-        version: link:../packages/editor-core
+        version: link:../../packages/editor-core
       '@sw-editor/editor-host-client':
         specifier: workspace:*
-        version: link:../packages/editor-host-client
+        version: link:../../packages/editor-host-client
     devDependencies:
       typescript:
         specifier: 5.9.3


### PR DESCRIPTION
## Summary

- `pnpm-workspace.yaml` already had `"example/e2e-harness"` replacing `"demo"` (done in phase 1, PR #163)
- Ran `pnpm install` to regenerate `pnpm-lock.yaml` with the updated workspace paths
- Lockfile now resolves `@sw-editor/example-e2e-harness` at `example/e2e-harness` with correct relative link paths

## Test plan
- [x] `pnpm-workspace.yaml` does not reference `"demo"`
- [x] `pnpm-workspace.yaml` includes `"example/e2e-harness"`
- [x] `pnpm install` succeeds and `pnpm list --filter @sw-editor/example-e2e-harness` resolves correctly

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)