### PR TITLE
docs: update stale @sw-editor/demo references to @sw-editor/example-e2e-harness

### DIFF
--- a/specs/001-visual-authoring-mvp/cross-check-findings.md
+++ b/specs/001-visual-authoring-mvp/cross-check-findings.md
@@ -344,10 +344,10 @@
 
 **Requirement IDs affected**: SC-001, SC-007
 
-**Resolution** (tasks #141 and #126):
-- `playwright.config.ts` now has a `webServer` block that runs `pnpm --filter @sw-editor/demo build && pnpm --filter @sw-editor/demo preview` and waits for `http://localhost:4173`.
-- `demo/vite.config.ts` adds aliases for `@sw-editor/editor-core` and `@sw-editor/editor-host-client/rete-lit` (following the same pattern as `example/vanilla-js/vite.config.ts`) so the demo builds from TypeScript source without a separate package build step.
-- `pnpm test:e2e` now starts the demo automatically.  Tests that require the full `sw-editor` component are marked `test.fixme`; structural smoke tests (ARIA landmarks, live-region presence) are left active.
+**Resolution** (tasks #141, #126, and #157):
+- `playwright.config.ts` now has a `webServer` block that runs `pnpm --filter @sw-editor/example-e2e-harness build && pnpm --filter @sw-editor/example-e2e-harness preview` and waits for `http://localhost:4173`.
+- `example/e2e-harness/vite.config.ts` adds aliases for `@sw-editor/editor-core` and `@sw-editor/editor-host-client/rete-lit` (following the same pattern as `example/vanilla-js/vite.config.ts`) so the harness builds from TypeScript source without a separate package build step.
+- `pnpm test:e2e` now starts the e2e harness automatically.  Tests that require the full `sw-editor` component are marked `test.fixme`; structural smoke tests (ARIA landmarks, live-region presence) are left active.
 
 **SC-007 status**: CONFIRMED COVERED.
 **SC-001 status**: Infrastructure complete; full coverage requires `sw-editor` component implementation (remove `test.fixme` markers at that point).


### PR DESCRIPTION
## Summary

- `playwright.config.ts` was already updated to `@sw-editor/example-e2e-harness` in PR #163 (Phase 1 move) — all acceptance criteria for task #157 were already satisfied on `main`
- This PR updates the stale `@sw-editor/demo` reference in `specs/001-visual-authoring-mvp/cross-check-findings.md` to match current reality (package renamed, directory moved from `demo/` to `example/e2e-harness/`)
- No `.github/workflows/` files exist in the repository to audit

Closes #157

## Test plan

- [x] `playwright.config.ts` contains no references to `@sw-editor/demo` or `demo/`
- [x] `--filter @sw-editor/example-e2e-harness` is used in the `webServer` command
- [x] No `.github/workflows/*.yml` files reference `demo` or `@sw-editor/demo`
- [x] `cross-check-findings.md` now reflects current package name and directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)