### PR TITLE
feat(specs): add 005-align-example-demo spec.md

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -10,7 +10,7 @@ This repository now uses GitHub Spec Kit feature packages under `specs/`.
 | [`002-nested-tasks-ux`](002-nested-tasks-ux/) | Planned | Visual authoring support for nested task structures with expanded default rendering. |
 | [`003-branching-control-flow`](003-branching-control-flow/) | Planned | Panel-driven authoring for transition, if, switch, fork, and try-catch behavior with route projection. |
 | [`004-extensibility-customization`](004-extensibility-customization/) | Planned | Plugin architecture for custom rendering, validation, commands, and slot-based UI extensions. |
-| [`005-align-example-demo`](005-align-example-demo/) | Draft | Consolidate `demo/` into `example/e2e-harness/` with package `@sw-editor/example-e2e-harness` under the unified `example/` top-level directory. |
+| [`005-align-example-demo`](005-align-example-demo/) | Implemented | Consolidate `demo/` into `example/e2e-harness/` with package `@sw-editor/example-e2e-harness` under the unified `example/` top-level directory. |
 
 Each feature package contains:
 


### PR DESCRIPTION
## Summary

- `specs/005-align-example-demo/spec.md` already existed and is complete with all required content: terminology decision (`example/e2e-harness/` / `@sw-editor/example-e2e-harness`), full scope table, functional requirements, success criteria, and status.
- `specs/005-align-example-demo/checklists/requirements.md` is fully checked (all items pass).
- Fixed a status inconsistency: `specs/README.md` showed `Draft` while the spec itself (correctly) showed `Implemented` — updated README to match.

## Test plan

- [x] `specs/005-align-example-demo/spec.md` exists and documents terminology decision and scope
- [x] Status field in spec.md is `Implemented` (feature is complete)
- [x] `specs/README.md` reflects `Implemented` status for feature 005
- [x] Quality checklist at `checklists/requirements.md` is fully checked

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)