### PR TITLE
feat(e2e-harness): add missing Vite aliases for react-flow adapter

### DIFF
--- a/example/e2e-harness/vite.config.ts
+++ b/example/e2e-harness/vite.config.ts
@@ -18,6 +18,14 @@ export default defineConfig({
         replacement: resolve(__dirname, "../../packages/editor-host-client/src/rete-lit.ts"),
       },
       {
+        find: "@sw-editor/editor-host-client/react-flow",
+        replacement: resolve(__dirname, "../../packages/editor-host-client/src/react-flow.ts"),
+      },
+      {
+        find: "@sw-editor/editor-renderer-react-flow",
+        replacement: resolve(__dirname, "../../packages/editor-renderer-react-flow/src/index.ts"),
+      },
+      {
         find: "@sw-editor/editor-host-client",
         replacement: resolve(__dirname, "../../packages/editor-host-client/src/index.ts"),
       },


### PR DESCRIPTION
## Summary

- Add `@sw-editor/editor-host-client/react-flow` alias pointing to `packages/editor-host-client/src/react-flow.ts`
- Add `@sw-editor/editor-renderer-react-flow` alias pointing to `packages/editor-renderer-react-flow/src/index.ts`
- Both new sub-path aliases are placed before the root `@sw-editor/editor-host-client` alias to avoid override conflicts

Closes #174

## Test plan

- [ ] `pnpm --filter @sw-editor/example-e2e-harness build` completes without resolve errors
- [ ] Verify both new alias entries appear before the root package alias in `vite.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)