### PR TITLE
feat(e2e-harness): add @sw-editor/editor-renderer-react-flow dependency

### DIFF
--- a/example/e2e-harness/package.json
+++ b/example/e2e-harness/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "@sw-editor/editor-core": "workspace:*",
-    "@sw-editor/editor-host-client": "workspace:*"
+    "@sw-editor/editor-host-client": "workspace:*",
+    "@sw-editor/editor-renderer-react-flow": "workspace:*"
   },
   "devDependencies": {
     "typescript": "5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@sw-editor/editor-host-client':
         specifier: workspace:*
         version: link:../../packages/editor-host-client
+      '@sw-editor/editor-renderer-react-flow':
+        specifier: workspace:*
+        version: link:../../packages/editor-renderer-react-flow
     devDependencies:
       typescript:
         specifier: 5.9.3


### PR DESCRIPTION
## Summary

- Added `@sw-editor/editor-renderer-react-flow": "workspace:*"` to `dependencies` in `example/e2e-harness/package.json`
- Ran `pnpm install` to regenerate `pnpm-lock.yaml` with the new workspace link

## Why

Ensures React + ReactDOM peer dependencies resolve correctly via the workspace, keeping the dependency graph intentional.

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)