### PR TITLE
feat(e2e-harness): make SwEditorElement adapter-agnostic via ?renderer= param

### DIFF
--- a/example/e2e-harness/main.ts
+++ b/example/e2e-harness/main.ts
@@ -1,9 +1,11 @@
 /**
  * Demo entry point — registers the `sw-editor` custom element.
  *
- * Imports the `rete-lit` renderer backend from `@sw-editor/editor-host-client`
- * and defines the `<sw-editor>` custom element. The element bootstraps an empty
- * workflow graph (start → end), mounts the rete-lit renderer, and attaches
+ * Imports both renderer backends from `@sw-editor/editor-host-client` and
+ * defines the `<sw-editor>` custom element. The active renderer is chosen at
+ * runtime via the `?renderer=` URL search parameter (values: `"react-flow"` |
+ * `"rete-lit"`, default `"rete-lit"`). The element bootstraps an empty
+ * workflow graph (start → end), mounts the selected renderer, and attaches
  * insertion affordance buttons for each graph edge so that Scenario 2 of the
  * quickstart can be exercised end-to-end.
  *
@@ -24,6 +26,7 @@ import {
   validateWorkflow,
 } from "@sw-editor/editor-core";
 import { ReteLitAdapter } from "@sw-editor/editor-host-client/rete-lit";
+import { ReactFlowAdapter } from "@sw-editor/editor-host-client/react-flow";
 
 // ---------------------------------------------------------------------------
 // Task type catalogue (mirrors InsertionUI.MVP_TASK_TYPES)
@@ -89,7 +92,7 @@ const MVP_TASK_TYPES: readonly TaskTypeDescriptor[] = [
  */
 class SwEditorElement extends HTMLElement {
   /** Active renderer adapter, present only while the element is connected. */
-  #adapter: ReteLitAdapter | null = null;
+  #adapter: ReteLitAdapter | ReactFlowAdapter | null = null;
 
   /** Current in-memory workflow graph. */
   #graph: WorkflowGraph | null = null;
@@ -104,13 +107,15 @@ class SwEditorElement extends HTMLElement {
   /**
    * Called by the browser when the element is inserted into the document.
    *
-   * Creates the rete-lit renderer canvas, bootstraps the initial workflow
-   * graph, mounts the renderer, and renders the first set of affordances.
+   * Reads the `?renderer=` URL search parameter to select the active renderer
+   * backend (`"react-flow"` or `"rete-lit"`, defaulting to `"rete-lit"`),
+   * creates the renderer canvas, bootstraps the initial workflow graph, mounts
+   * the renderer, and renders the first set of affordances.
    */
   connectedCallback(): void {
-    // Create an inner div for the rete canvas so rete's overflow:hidden does
-    // not clip sibling elements (affordance buttons, task menus) we append to
-    // `this`.
+    // Create an inner div for the renderer canvas so the renderer's
+    // overflow:hidden does not clip sibling elements (affordance buttons, task
+    // menus) we append to `this`.
     const canvas = document.createElement("div");
     canvas.style.width = "100%";
     canvas.style.height = "100%";
@@ -119,7 +124,12 @@ class SwEditorElement extends HTMLElement {
     this.#counter = new RevisionCounter();
     this.#graph = bootstrapWorkflowGraph();
 
-    this.#adapter = new ReteLitAdapter();
+    const renderer = new URLSearchParams(location.search).get("renderer");
+    if (renderer === "react-flow") {
+      this.#adapter = new ReactFlowAdapter();
+    } else {
+      this.#adapter = new ReteLitAdapter();
+    }
     this.#adapter.mount(canvas, this.#graph);
 
     this.#syncAffordances();

--- a/packages/editor-host-client/src/react-flow.ts
+++ b/packages/editor-host-client/src/react-flow.ts
@@ -47,3 +47,4 @@ export function getCapabilities(): CapabilitySnapshot {
 
 export type { CapabilitySnapshot };
 export type { RendererCapabilitySnapshot } from "./contracts/capabilities.js";
+export { ReactFlowAdapter } from "@sw-editor/editor-renderer-react-flow";


### PR DESCRIPTION
## Summary

- Reads `new URLSearchParams(location.search).get("renderer")` in `connectedCallback` to select the active renderer at runtime
- Instantiates `ReactFlowAdapter` when `?renderer=react-flow`, falls back to `ReteLitAdapter` for any other value (default `"rete-lit"` behaviour preserved)
- Updates `#adapter` type annotation to `ReteLitAdapter | ReactFlowAdapter | null`
- Re-exports `ReactFlowAdapter` from `@sw-editor/editor-host-client/react-flow` entry point (mirrors the existing `ReteLitAdapter` re-export in the `rete-lit` entry point)

Closes #175

## Test plan

- [ ] `http://localhost:4173` (no query string) — uses `ReteLitAdapter` as before
- [ ] `http://localhost:4173/?renderer=react-flow` — uses `ReactFlowAdapter`
- [ ] `http://localhost:4173/?renderer=rete-lit` — uses `ReteLitAdapter`

🤖 Generated with [Claude Code](https://claude.com/claude-code)