### PR TITLE
feat(e2e-harness): add renderer switcher UI to index.html

### DIFF
--- a/example/e2e-harness/index.html
+++ b/example/e2e-harness/index.html
@@ -15,6 +15,11 @@
     <header>
       <!-- Toolbar: workflow-level actions required by quickstart and accessibility scenarios -->
       <button type="button" aria-label="Create new workflow">New Workflow</button>
+      <label for="renderer-select" style="margin-left:1rem;font-size:0.875rem;">Renderer:</label>
+      <select id="renderer-select" aria-label="Select renderer" style="margin-left:0.25rem;">
+        <option value="rete-lit">rete-lit</option>
+        <option value="react-flow">react-flow</option>
+      </select>
     </header>
     <main>
       <sw-editor id="editor" style="width:100%;height:100%;position:relative;"></sw-editor>

--- a/example/e2e-harness/main.ts
+++ b/example/e2e-harness/main.ts
@@ -540,3 +540,33 @@ function wireDiagnostics(): void {
 }
 
 wireDiagnostics();
+
+// ---------------------------------------------------------------------------
+// Renderer switcher wiring
+// ---------------------------------------------------------------------------
+
+/**
+ * Wires the `#renderer-select` element so that choosing a renderer updates
+ * the `?renderer=` URL search parameter and reloads the page.
+ *
+ * Also sets the select's initial value from the current URL parameter so the
+ * control reflects the active renderer on page load.
+ */
+function wireRendererSelect(): void {
+  const select = document.querySelector<HTMLSelectElement>("#renderer-select");
+  if (!select) return;
+
+  // Reflect the active renderer in the select on page load.
+  const current = new URLSearchParams(location.search).get("renderer");
+  if (current === "react-flow" || current === "rete-lit") {
+    select.value = current;
+  }
+
+  select.addEventListener("change", () => {
+    const params = new URLSearchParams(location.search);
+    params.set("renderer", select.value);
+    location.search = params.toString();
+  });
+}
+
+wireRendererSelect();


### PR DESCRIPTION
## Summary

- Added `<select id="renderer-select">` with `rete-lit` and `react-flow` options inside `<header>` in `index.html`
- Added `wireRendererSelect()` function in `main.ts` that sets the select's initial value from `?renderer=` on page load and reloads the page with the updated param on change
- Existing Playwright e2e tests unaffected — no `?renderer=` defaults to `rete-lit` unchanged

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)