### PR TITLE
fix(quality-gate): resolve lint, build, and type errors after react-flow harness integration

### DIFF
--- a/example/e2e-harness/main.ts
+++ b/example/e2e-harness/main.ts
@@ -25,8 +25,8 @@ import {
   RevisionCounter,
   validateWorkflow,
 } from "@sw-editor/editor-core";
-import { ReteLitAdapter } from "@sw-editor/editor-host-client/rete-lit";
 import { ReactFlowAdapter } from "@sw-editor/editor-host-client/react-flow";
+import { ReteLitAdapter } from "@sw-editor/editor-host-client/rete-lit";
 
 // ---------------------------------------------------------------------------
 // Task type catalogue (mirrors InsertionUI.MVP_TASK_TYPES)
@@ -523,8 +523,7 @@ function wireDiagnostics(): void {
         return;
       }
 
-      const format =
-        content.startsWith("{") || content.startsWith("[") ? "json" : "yaml";
+      const format = content.startsWith("{") || content.startsWith("[") ? "json" : "yaml";
 
       const diagnostics = validateWorkflow({ format, content });
 

--- a/example/e2e-harness/vite.config.ts
+++ b/example/e2e-harness/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import { resolve } from "node:path";
+import { defineConfig } from "vite";
 
 /**
  * Vite configuration for the e2e harness app.

--- a/example/host-events/index.html
+++ b/example/host-events/index.html
@@ -101,12 +101,12 @@
     </p>
 
     <div class="controls">
-      <button id="btn-simulate-load">Simulate workflow load event</button>
-      <button id="btn-simulate-diag">Simulate diagnostics event</button>
-      <button id="btn-simulate-selection">Simulate selection event</button>
-      <button id="btn-simulate-error" class="secondary">Simulate error event</button>
-      <button id="btn-get-cap">Query capabilities</button>
-      <button id="btn-clear" class="danger">Clear log</button>
+      <button type="button" id="btn-simulate-load">Simulate workflow load event</button>
+      <button type="button" id="btn-simulate-diag">Simulate diagnostics event</button>
+      <button type="button" id="btn-simulate-selection">Simulate selection event</button>
+      <button type="button" id="btn-simulate-error" class="secondary">Simulate error event</button>
+      <button type="button" id="btn-get-cap">Query capabilities</button>
+      <button type="button" id="btn-clear" class="danger">Clear log</button>
     </div>
 
     <div class="panels">

--- a/example/host-events/main.ts
+++ b/example/host-events/main.ts
@@ -21,20 +21,20 @@
  * @module example/host-events/main
  */
 
-import { EventBridge } from "@sw-editor/editor-web-component";
-import {
-  EditorEventName,
-  CONTRACT_VERSION,
-  TARGET_VERSION,
-  SUPPORTED_VERSIONS,
-} from "@sw-editor/editor-host-client";
 import type {
-  WorkflowChangedPayload,
-  EditorDiagnosticsChangedPayload,
-  EditorSelectionChangedPayload,
-  EditorErrorPayload,
   CapabilitySnapshot,
+  EditorDiagnosticsChangedPayload,
+  EditorErrorPayload,
+  EditorSelectionChangedPayload,
+  WorkflowChangedPayload,
 } from "@sw-editor/editor-host-client";
+import {
+  CONTRACT_VERSION,
+  EditorEventName,
+  SUPPORTED_VERSIONS,
+  TARGET_VERSION,
+} from "@sw-editor/editor-host-client";
+import { EventBridge } from "@sw-editor/editor-web-component";
 
 // ---------------------------------------------------------------------------
 // Shared event target — in a real integration this would be the <sw-editor>
@@ -176,8 +176,7 @@ btnGetCap.addEventListener("click", () => {
 
 /** Clears the event log. */
 btnClear.addEventListener("click", () => {
-  eventList.innerHTML =
-    '<li><span class="empty">No events yet — click a button above.</span></li>';
+  eventList.innerHTML = '<li><span class="empty">No events yet — click a button above.</span></li>';
   eventCount.textContent = "0";
   _eventTotal = 0;
 });

--- a/example/host-events/vite.config.ts
+++ b/example/host-events/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import { resolve } from "node:path";
+import { defineConfig } from "vite";
 
 /**
  * Vite configuration for the host-events example.
@@ -18,10 +18,7 @@ export default defineConfig({
         __dirname,
         "../../packages/editor-web-component/src/index.ts",
       ),
-      "@sw-editor/editor-core": resolve(
-        __dirname,
-        "../../packages/editor-core/src/index.ts",
-      ),
+      "@sw-editor/editor-core": resolve(__dirname, "../../packages/editor-core/src/index.ts"),
     },
   },
 });

--- a/example/playwright.config.ts
+++ b/example/playwright.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig, devices } from "@playwright/test";
 import path from "node:path";
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Playwright end-to-end test configuration for the example apps.
@@ -17,7 +17,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: [["html", { open: "never", outputFolder: path.join(__dirname, "../playwright-report-examples") }]],
+  reporter: [
+    [
+      "html",
+      { open: "never", outputFolder: path.join(__dirname, "../playwright-report-examples") },
+    ],
+  ],
   projects: [
     {
       name: "vanilla-js",

--- a/example/tests/host-events.spec.ts
+++ b/example/tests/host-events.spec.ts
@@ -16,7 +16,7 @@
  * @module example/tests/host-events.spec
  */
 
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
 // Selectors — match the IDs defined in example/host-events/index.html
@@ -60,7 +60,14 @@ test.describe("host-events example — page load", () => {
 
   test("all simulation buttons are visible and enabled", async ({ page }) => {
     await page.goto("/");
-    for (const selector of [BTN_SIMULATE_LOAD, BTN_SIMULATE_DIAG, BTN_SIMULATE_SELECTION, BTN_SIMULATE_ERROR, BTN_GET_CAP, BTN_CLEAR]) {
+    for (const selector of [
+      BTN_SIMULATE_LOAD,
+      BTN_SIMULATE_DIAG,
+      BTN_SIMULATE_SELECTION,
+      BTN_SIMULATE_ERROR,
+      BTN_GET_CAP,
+      BTN_CLEAR,
+    ]) {
       await expect(page.locator(selector)).toBeVisible();
       await expect(page.locator(selector)).toBeEnabled();
     }

--- a/example/tests/vanilla-js.spec.ts
+++ b/example/tests/vanilla-js.spec.ts
@@ -14,7 +14,7 @@
  * @module example/tests/vanilla-js.spec
  */
 
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
 // Selectors — match the IDs defined in example/vanilla-js/index.html

--- a/example/vanilla-js/index.html
+++ b/example/vanilla-js/index.html
@@ -58,14 +58,14 @@
 
     <div class="card">
       <h2>1. Load workflow from fixture</h2>
-      <button id="btn-load">Load simple.json fixture</button>
+      <button type="button" id="btn-load">Load simple.json fixture</button>
       <p class="status" id="load-status">Not loaded yet.</p>
     </div>
 
     <div class="card">
       <h2>2. Export workflow</h2>
-      <button id="btn-export" disabled>Export as JSON</button>
-      <button id="btn-export-yaml" disabled style="margin-left:0.5rem">Export as YAML</button>
+      <button type="button" id="btn-export" disabled>Export as JSON</button>
+      <button type="button" id="btn-export-yaml" disabled style="margin-left:0.5rem">Export as YAML</button>
       <p class="status" id="export-status">Load a workflow first.</p>
     </div>
 

--- a/example/vanilla-js/main.ts
+++ b/example/vanilla-js/main.ts
@@ -18,8 +18,8 @@
  * @module example/vanilla-js/main
  */
 
-import { exportWorkflowSource, setCurrentSource } from "@sw-editor/editor-host-client";
 import type { WorkflowSource } from "@sw-editor/editor-host-client";
+import { exportWorkflowSource, setCurrentSource } from "@sw-editor/editor-host-client";
 
 // The fixture is bundled at build time — no runtime network call needed.
 import simpleWorkflow from "../../tests/fixtures/valid/simple.json";
@@ -108,11 +108,7 @@ async function runExport(format: "json" | "yaml"): Promise<void> {
  * @param text - New text content.
  * @param cssClass - CSS class to apply: `"ok"`, `"error"`, or `""` for neutral.
  */
-function setStatus(
-  el: HTMLParagraphElement,
-  text: string,
-  cssClass: "ok" | "error" | "",
-): void {
+function setStatus(el: HTMLParagraphElement, text: string, cssClass: "ok" | "error" | ""): void {
   el.textContent = text;
   el.className = `status${cssClass ? ` ${cssClass}` : ""}`;
 }

--- a/example/vanilla-js/vite.config.ts
+++ b/example/vanilla-js/vite.config.ts
@@ -1,5 +1,5 @@
-import { defineConfig } from "vite";
 import { resolve } from "node:path";
+import { defineConfig } from "vite";
 
 /**
  * Vite configuration for the vanilla-js example.
@@ -14,10 +14,7 @@ export default defineConfig({
         __dirname,
         "../../packages/editor-host-client/src/index.ts",
       ),
-      "@sw-editor/editor-core": resolve(
-        __dirname,
-        "../../packages/editor-core/src/index.ts",
-      ),
+      "@sw-editor/editor-core": resolve(__dirname, "../../packages/editor-core/src/index.ts"),
     },
   },
 });

--- a/packages/editor-host-client/src/react-flow.ts
+++ b/packages/editor-host-client/src/react-flow.ts
@@ -46,5 +46,5 @@ export function getCapabilities(): CapabilitySnapshot {
 }
 
 export type { CapabilitySnapshot };
-export type { RendererCapabilitySnapshot } from "./contracts/capabilities.js";
 export { ReactFlowAdapter } from "@sw-editor/editor-renderer-react-flow";
+export type { RendererCapabilitySnapshot } from "./contracts/capabilities.js";

--- a/packages/editor-host-client/src/rete-lit.ts
+++ b/packages/editor-host-client/src/rete-lit.ts
@@ -46,5 +46,5 @@ export function getCapabilities(): CapabilitySnapshot {
 }
 
 export type { CapabilitySnapshot };
-export type { RendererCapabilitySnapshot } from "./contracts/capabilities.js";
 export { ReteLitAdapter } from "@sw-editor/editor-renderer-rete-lit";
+export type { RendererCapabilitySnapshot } from "./contracts/capabilities.js";

--- a/packages/editor-host-client/tests/capabilities.spec.ts
+++ b/packages/editor-host-client/tests/capabilities.spec.ts
@@ -8,13 +8,13 @@
  */
 
 import { describe, expect, it } from "vitest";
+import type { RendererCapabilitySnapshot } from "../src/contracts/capabilities.js";
 import {
   CONTRACT_VERSION,
+  createCapabilitySnapshot,
   SUPPORTED_VERSIONS,
   TARGET_VERSION,
-  createCapabilitySnapshot,
 } from "../src/contracts/capabilities.js";
-import type { RendererCapabilitySnapshot } from "../src/contracts/capabilities.js";
 
 // ---------------------------------------------------------------------------
 // Shared test fixture — a minimal RendererCapabilitySnapshot for a rete-lit renderer.

--- a/packages/editor-host-client/tests/export.spec.ts
+++ b/packages/editor-host-client/tests/export.spec.ts
@@ -7,13 +7,8 @@
  */
 
 import { beforeEach, describe, expect, it } from "vitest";
-
-import {
-  exportWorkflowSource,
-  getCurrentSource,
-  setCurrentSource,
-} from "../src/export.js";
 import type { WorkflowSource } from "../src/contracts/types.js";
+import { exportWorkflowSource, getCurrentSource, setCurrentSource } from "../src/export.js";
 
 // ---------------------------------------------------------------------------
 // Fixtures

--- a/packages/editor-web-component/src/graph/insertion-ui.ts
+++ b/packages/editor-web-component/src/graph/insertion-ui.ts
@@ -328,7 +328,7 @@ export class InsertionUI {
       item.setAttribute("role", "menuitem");
       item.className = "sw-task-menu__item";
       item.textContent = taskType.label;
-      item.dataset.taskTypeId = taskType.id;
+      item.dataset["taskTypeId"] = taskType.id;
 
       item.addEventListener("click", () => {
         this.closeTaskMenu();

--- a/tests/e2e/accessibility-mvp.spec.ts
+++ b/tests/e2e/accessibility-mvp.spec.ts
@@ -100,396 +100,405 @@ async function openEditor(page: import("@playwright/test").Page): Promise<void> 
 // 1. New workflow creation — keyboard operability
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Keyboard operability — create new workflow", () => {
-  test("new-workflow button is reachable via Tab and activatable via Enter", async ({ page }) => {
-    await openEditor(page);
+test.describe
+  .fixme("Keyboard operability — create new workflow", () => {
+    test("new-workflow button is reachable via Tab and activatable via Enter", async ({ page }) => {
+      await openEditor(page);
 
-    // Tab into the editor and locate the new-workflow button via keyboard.
-    await page.keyboard.press("Tab");
+      // Tab into the editor and locate the new-workflow button via keyboard.
+      await page.keyboard.press("Tab");
 
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.focus();
-    await expect(newWorkflowBtn).toBeFocused();
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.focus();
+      await expect(newWorkflowBtn).toBeFocused();
 
-    // Activate using Enter — no mouse required.
-    await newWorkflowBtn.press("Enter");
+      // Activate using Enter — no mouse required.
+      await newWorkflowBtn.press("Enter");
 
-    // After creation the graph should contain start and end nodes.
-    await expect(page.locator('[data-node-type="start"]')).toBeVisible();
-    await expect(page.locator('[data-node-type="end"]')).toBeVisible();
+      // After creation the graph should contain start and end nodes.
+      await expect(page.locator('[data-node-type="start"]')).toBeVisible();
+      await expect(page.locator('[data-node-type="end"]')).toBeVisible();
+    });
+
+    test("new-workflow button is activatable via Space", async ({ page }) => {
+      await openEditor(page);
+
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.focus();
+      await newWorkflowBtn.press(" ");
+
+      await expect(page.locator('[data-node-type="start"]')).toBeVisible();
+    });
+
+    test("new-workflow button has a non-empty accessible name", async ({ page }) => {
+      await openEditor(page);
+
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await expect(newWorkflowBtn).toHaveAttribute("aria-label", "Create new workflow");
+    });
   });
-
-  test("new-workflow button is activatable via Space", async ({ page }) => {
-    await openEditor(page);
-
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.focus();
-    await newWorkflowBtn.press(" ");
-
-    await expect(page.locator('[data-node-type="start"]')).toBeVisible();
-  });
-
-  test("new-workflow button has a non-empty accessible name", async ({ page }) => {
-    await openEditor(page);
-
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await expect(newWorkflowBtn).toHaveAttribute("aria-label", "Create new workflow");
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 2. Task insertion — keyboard operability
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Keyboard operability — task insertion", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    // Start each insertion test from a fresh single-edge workflow.
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.focus();
-    await newWorkflowBtn.press("Enter");
+test.describe
+  .fixme("Keyboard operability — task insertion", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      // Start each insertion test from a fresh single-edge workflow.
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.focus();
+      await newWorkflowBtn.press("Enter");
+    });
+
+    test("insertion affordance button carries correct aria-label", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await expect(affordance).toHaveAttribute("aria-label", "Insert task");
+    });
+
+    test("insertion affordance is reachable via Tab navigation", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.focus();
+      await expect(affordance).toBeFocused();
+    });
+
+    test("pressing Enter on affordance opens the task type menu", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.focus();
+      await affordance.press("Enter");
+
+      const menu = page.locator(TASK_MENU_SELECTOR);
+      await expect(menu).toBeVisible();
+    });
+
+    test("pressing Space on affordance opens the task type menu", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.focus();
+      await affordance.press(" ");
+
+      await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
+    });
+
+    test("task menu receives initial focus on the first menu item", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await expect(firstItem).toBeFocused();
+    });
+
+    test("task menu supports ArrowDown navigation between items", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await expect(firstItem).toBeFocused();
+
+      await page.keyboard.press("ArrowDown");
+
+      const secondItem = page.locator(TASK_MENU_ITEM_SELECTOR).nth(1);
+      await expect(secondItem).toBeFocused();
+    });
+
+    test("task menu supports ArrowUp navigation between items", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      // Navigate down then back up.
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("ArrowUp");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await expect(firstItem).toBeFocused();
+    });
+
+    test("pressing Escape closes the task menu and returns focus to affordance", async ({
+      page,
+    }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
+
+      await page.keyboard.press("Escape");
+
+      await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
+      // Focus must return to the affordance that opened the menu.
+      await expect(affordance).toBeFocused();
+    });
+
+    test("selecting a task type via Enter inserts the task and moves focus", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      // Select the first task type using Enter.
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      // Menu must close after selection.
+      await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
+
+      // A new node must appear in the graph.
+      const nodes = page.locator('[data-testid="graph-node"]');
+      await expect(nodes).not.toHaveCount(0);
+    });
+
+    test("task menu items have role=menuitem", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const items = page.locator(TASK_MENU_ITEM_SELECTOR);
+      // Verify at least one item exists and carries the correct role.
+      await expect(items.first()).toHaveAttribute("role", "menuitem");
+    });
+
+    test("task type menu has role=menu with a descriptive aria-label", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const menu = page.locator(TASK_MENU_SELECTOR);
+      await expect(menu).toHaveAttribute("role", "menu");
+      await expect(menu).toHaveAttribute("aria-label", "Select task type to insert");
+    });
   });
-
-  test("insertion affordance button carries correct aria-label", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await expect(affordance).toHaveAttribute("aria-label", "Insert task");
-  });
-
-  test("insertion affordance is reachable via Tab navigation", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.focus();
-    await expect(affordance).toBeFocused();
-  });
-
-  test("pressing Enter on affordance opens the task type menu", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.focus();
-    await affordance.press("Enter");
-
-    const menu = page.locator(TASK_MENU_SELECTOR);
-    await expect(menu).toBeVisible();
-  });
-
-  test("pressing Space on affordance opens the task type menu", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.focus();
-    await affordance.press(" ");
-
-    await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
-  });
-
-  test("task menu receives initial focus on the first menu item", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await expect(firstItem).toBeFocused();
-  });
-
-  test("task menu supports ArrowDown navigation between items", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await expect(firstItem).toBeFocused();
-
-    await page.keyboard.press("ArrowDown");
-
-    const secondItem = page.locator(TASK_MENU_ITEM_SELECTOR).nth(1);
-    await expect(secondItem).toBeFocused();
-  });
-
-  test("task menu supports ArrowUp navigation between items", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    // Navigate down then back up.
-    await page.keyboard.press("ArrowDown");
-    await page.keyboard.press("ArrowUp");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await expect(firstItem).toBeFocused();
-  });
-
-  test("pressing Escape closes the task menu and returns focus to affordance", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
-
-    await page.keyboard.press("Escape");
-
-    await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
-    // Focus must return to the affordance that opened the menu.
-    await expect(affordance).toBeFocused();
-  });
-
-  test("selecting a task type via Enter inserts the task and moves focus", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    // Select the first task type using Enter.
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    // Menu must close after selection.
-    await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
-
-    // A new node must appear in the graph.
-    const nodes = page.locator('[data-testid="graph-node"]');
-    await expect(nodes).not.toHaveCount(0);
-  });
-
-  test("task menu items have role=menuitem", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const items = page.locator(TASK_MENU_ITEM_SELECTOR);
-    // Verify at least one item exists and carries the correct role.
-    await expect(items.first()).toHaveAttribute("role", "menuitem");
-  });
-
-  test("task type menu has role=menu with a descriptive aria-label", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const menu = page.locator(TASK_MENU_SELECTOR);
-    await expect(menu).toHaveAttribute("role", "menu");
-    await expect(menu).toHaveAttribute("aria-label", "Select task type to insert");
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 3. Node navigation — keyboard operability
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Keyboard operability — node navigation", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
-  });
+test.describe
+  .fixme("Keyboard operability — node navigation", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+    });
 
-  test("graph nodes are reachable via Tab key", async ({ page }) => {
-    // Tab through interactive elements until a graph node receives focus.
-    const graphNode = page.locator('[data-testid="graph-node"]').first();
-    await graphNode.focus();
-    await expect(graphNode).toBeFocused();
-  });
+    test("graph nodes are reachable via Tab key", async ({ page }) => {
+      // Tab through interactive elements until a graph node receives focus.
+      const graphNode = page.locator('[data-testid="graph-node"]').first();
+      await graphNode.focus();
+      await expect(graphNode).toBeFocused();
+    });
 
-  test("graph nodes are focusable and have a non-empty accessible name", async ({ page }) => {
-    const startNode = page.locator('[data-node-type="start"]');
-    await startNode.focus();
-    // The node must have either an aria-label or an accessible text name.
-    const ariaLabel = await startNode.getAttribute("aria-label");
-    const innerText = await startNode.innerText();
-    expect(
-      (ariaLabel ?? "").length + innerText.length,
-      "Graph node must have a non-empty accessible name",
-    ).toBeGreaterThan(0);
-  });
+    test("graph nodes are focusable and have a non-empty accessible name", async ({ page }) => {
+      const startNode = page.locator('[data-node-type="start"]');
+      await startNode.focus();
+      // The node must have either an aria-label or an accessible text name.
+      const ariaLabel = await startNode.getAttribute("aria-label");
+      const innerText = await startNode.innerText();
+      expect(
+        (ariaLabel ?? "").length + innerText.length,
+        "Graph node must have a non-empty accessible name",
+      ).toBeGreaterThan(0);
+    });
 
-  test("selecting a node via keyboard updates the properties panel", async ({ page }) => {
-    const startNode = page.locator('[data-node-type="start"]');
-    await startNode.focus();
-    await startNode.press("Enter");
+    test("selecting a node via keyboard updates the properties panel", async ({ page }) => {
+      const startNode = page.locator('[data-node-type="start"]');
+      await startNode.focus();
+      await startNode.press("Enter");
 
-    // The properties panel must reflect the selection.
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    await expect(panel).toBeVisible();
+      // The properties panel must reflect the selection.
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      await expect(panel).toBeVisible();
+    });
   });
-});
 
 // ---------------------------------------------------------------------------
 // 4. Property panel — keyboard operability
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Keyboard operability — property panel", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
+test.describe
+  .fixme("Keyboard operability — property panel", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+    });
+
+    test("property panel is visible and has an accessible region landmark", async ({ page }) => {
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      await expect(panel).toBeVisible();
+      await expect(panel).toHaveAttribute("aria-label", "Properties panel");
+    });
+
+    test("panel inputs are reachable via Tab navigation inside the panel", async ({ page }) => {
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      await expect(panel).toBeVisible();
+
+      // Tab into the panel and verify at least one focusable element is reached.
+      const firstInput = panel.locator("input, textarea, [role='textbox']").first();
+      await firstInput.focus();
+      await expect(firstInput).toBeFocused();
+    });
+
+    test("pressing Escape from a node closes its property context without trapping focus", async ({
+      page,
+    }) => {
+      // Select a node to open its property panel context.
+      const startNode = page.locator('[data-node-type="start"]');
+      await startNode.focus();
+      await startNode.press("Enter");
+
+      // Press Escape to deselect.
+      await page.keyboard.press("Escape");
+
+      // Panel should revert to workflow-level context; focus must not be trapped.
+      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+      await expect(panel).toBeVisible();
+    });
   });
-
-  test("property panel is visible and has an accessible region landmark", async ({ page }) => {
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    await expect(panel).toBeVisible();
-    await expect(panel).toHaveAttribute("aria-label", "Properties panel");
-  });
-
-  test("panel inputs are reachable via Tab navigation inside the panel", async ({ page }) => {
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    await expect(panel).toBeVisible();
-
-    // Tab into the panel and verify at least one focusable element is reached.
-    const firstInput = panel.locator("input, textarea, [role='textbox']").first();
-    await firstInput.focus();
-    await expect(firstInput).toBeFocused();
-  });
-
-  test("pressing Escape from a node closes its property context without trapping focus", async ({
-    page,
-  }) => {
-    // Select a node to open its property panel context.
-    const startNode = page.locator('[data-node-type="start"]');
-    await startNode.focus();
-    await startNode.press("Enter");
-
-    // Press Escape to deselect.
-    await page.keyboard.press("Escape");
-
-    // Panel should revert to workflow-level context; focus must not be trapped.
-    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-    await expect(panel).toBeVisible();
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 5. Export — keyboard operability
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Keyboard operability — export workflow", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
+test.describe
+  .fixme("Keyboard operability — export workflow", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+    });
+
+    test("export button is reachable via Tab and has correct aria-label", async ({ page }) => {
+      const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
+      await exportBtn.focus();
+      await expect(exportBtn).toBeFocused();
+      await expect(exportBtn).toHaveAttribute("aria-label", "Export workflow");
+    });
+
+    test("activating export via Enter opens the format selection UI", async ({ page }) => {
+      const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
+      await exportBtn.focus();
+      await exportBtn.press("Enter");
+
+      // Export format dialog or menu should appear.
+      const formatMenu = page.locator('[aria-label*="Export format"]');
+      await expect(formatMenu).toBeVisible();
+    });
+
+    test("export format options are navigable and selectable via keyboard", async ({ page }) => {
+      const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
+      await exportBtn.press("Enter");
+
+      // Navigate to JSON option using keyboard.
+      const jsonOption = page.locator('[data-export-format="json"]');
+      await jsonOption.focus();
+      await jsonOption.press("Enter");
+
+      // Export should complete without requiring mouse interaction.
+      // Verify no unhandled errors occurred.
+      const errorRegion = page.locator('[aria-label="Editor errors"]');
+      const hasError = await errorRegion.isVisible().catch(() => false);
+      expect(hasError, "Export should not produce visible errors").toBe(false);
+    });
   });
-
-  test("export button is reachable via Tab and has correct aria-label", async ({ page }) => {
-    const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
-    await exportBtn.focus();
-    await expect(exportBtn).toBeFocused();
-    await expect(exportBtn).toHaveAttribute("aria-label", "Export workflow");
-  });
-
-  test("activating export via Enter opens the format selection UI", async ({ page }) => {
-    const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
-    await exportBtn.focus();
-    await exportBtn.press("Enter");
-
-    // Export format dialog or menu should appear.
-    const formatMenu = page.locator('[aria-label*="Export format"]');
-    await expect(formatMenu).toBeVisible();
-  });
-
-  test("export format options are navigable and selectable via keyboard", async ({ page }) => {
-    const exportBtn = page.locator(EXPORT_BUTTON_SELECTOR);
-    await exportBtn.press("Enter");
-
-    // Navigate to JSON option using keyboard.
-    const jsonOption = page.locator('[data-export-format="json"]');
-    await jsonOption.focus();
-    await jsonOption.press("Enter");
-
-    // Export should complete without requiring mouse interaction.
-    // Verify no unhandled errors occurred.
-    const errorRegion = page.locator('[aria-label="Editor errors"]');
-    const hasError = await errorRegion.isVisible().catch(() => false);
-    expect(hasError, "Export should not produce visible errors").toBe(false);
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 6. Screen-reader announcements
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Screen-reader — ARIA live region announcements", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
+test.describe
+  .fixme("Screen-reader — ARIA live region announcements", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+    });
+
+    test("ARIA live region exists in the editor DOM", async ({ page }) => {
+      const liveRegion = page.locator(LIVE_REGION_SELECTOR);
+      await expect(liveRegion).toBeAttached();
+    });
+
+    test("live region uses aria-live=polite or assertive", async ({ page }) => {
+      const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
+      const ariaLive = await liveRegion.getAttribute("aria-live");
+      expect(["polite", "assertive"], "aria-live must be 'polite' or 'assertive'").toContain(
+        ariaLive,
+      );
+    });
+
+    test("selecting a node announces the panel context change", async ({ page }) => {
+      const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
+
+      // Capture initial announcement text.
+      const startNode = page.locator('[data-node-type="start"]');
+      await startNode.focus();
+      await startNode.press("Enter");
+
+      // The live region text should update to describe the node panel context.
+      await expect(liveRegion).not.toHaveText("");
+      const announcementText = await liveRegion.textContent();
+      expect(announcementText ?? "", "Live region must announce node selection").toContain("Node");
+    });
+
+    test("deselecting announces return to workflow panel context", async ({ page }) => {
+      const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
+
+      // Select a node then deselect.
+      const startNode = page.locator('[data-node-type="start"]');
+      await startNode.focus();
+      await startNode.press("Enter");
+      await page.keyboard.press("Escape");
+
+      // Live region should announce workflow-level context.
+      const announcementText = await liveRegion.textContent();
+      expect(
+        announcementText ?? "",
+        "Live region must announce workflow context on deselect",
+      ).toMatch(/workflow/i);
+    });
+
+    test("diagnostics live region announces validation errors", async ({ page }) => {
+      // Locate the diagnostics-specific live region (may be a separate element
+      // or the same as the general one, depending on implementation).
+      const diagnosticsRegion = page
+        .locator(
+          '[aria-label*="diagnostics" i], [aria-label*="validation" i], [data-testid="diagnostics-live-region"]',
+        )
+        .first();
+      await expect(diagnosticsRegion).toBeAttached();
+    });
   });
-
-  test("ARIA live region exists in the editor DOM", async ({ page }) => {
-    const liveRegion = page.locator(LIVE_REGION_SELECTOR);
-    await expect(liveRegion).toBeAttached();
-  });
-
-  test("live region uses aria-live=polite or assertive", async ({ page }) => {
-    const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
-    const ariaLive = await liveRegion.getAttribute("aria-live");
-    expect(["polite", "assertive"], "aria-live must be 'polite' or 'assertive'").toContain(
-      ariaLive,
-    );
-  });
-
-  test("selecting a node announces the panel context change", async ({ page }) => {
-    const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
-
-    // Capture initial announcement text.
-    const startNode = page.locator('[data-node-type="start"]');
-    await startNode.focus();
-    await startNode.press("Enter");
-
-    // The live region text should update to describe the node panel context.
-    await expect(liveRegion).not.toHaveText("");
-    const announcementText = await liveRegion.textContent();
-    expect(announcementText ?? "", "Live region must announce node selection").toContain("Node");
-  });
-
-  test("deselecting announces return to workflow panel context", async ({ page }) => {
-    const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
-
-    // Select a node then deselect.
-    const startNode = page.locator('[data-node-type="start"]');
-    await startNode.focus();
-    await startNode.press("Enter");
-    await page.keyboard.press("Escape");
-
-    // Live region should announce workflow-level context.
-    const announcementText = await liveRegion.textContent();
-    expect(
-      announcementText ?? "",
-      "Live region must announce workflow context on deselect",
-    ).toMatch(/workflow/i);
-  });
-
-  test("diagnostics live region announces validation errors", async ({ page }) => {
-    // Locate the diagnostics-specific live region (may be a separate element
-    // or the same as the general one, depending on implementation).
-    const diagnosticsRegion = page
-      .locator(
-        '[aria-label*="diagnostics" i], [aria-label*="validation" i], [data-testid="diagnostics-live-region"]',
-      )
-      .first();
-    await expect(diagnosticsRegion).toBeAttached();
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 7. Focus visibility
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Focus visibility", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
+test.describe
+  .fixme("Focus visibility", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+    });
+
+    test("focused insertion affordance has a visible focus indicator", async ({ page }) => {
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.focus();
+
+      // Capture bounding box before and after focus; a CSS outline or box-shadow
+      // changes the computed styles. We verify the element is at minimum reachable
+      // and reports as visible — style assertions are a best-effort check.
+      await expect(affordance).toBeVisible();
+      await expect(affordance).toBeFocused();
+    });
+
+    test("focused graph node has a visible focus indicator", async ({ page }) => {
+      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+      await newWorkflowBtn.press("Enter");
+
+      const startNode = page.locator('[data-node-type="start"]');
+      await startNode.focus();
+
+      await expect(startNode).toBeVisible();
+      await expect(startNode).toBeFocused();
+    });
   });
-
-  test("focused insertion affordance has a visible focus indicator", async ({ page }) => {
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
-
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.focus();
-
-    // Capture bounding box before and after focus; a CSS outline or box-shadow
-    // changes the computed styles. We verify the element is at minimum reachable
-    // and reports as visible — style assertions are a best-effort check.
-    await expect(affordance).toBeVisible();
-    await expect(affordance).toBeFocused();
-  });
-
-  test("focused graph node has a visible focus indicator", async ({ page }) => {
-    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-    await newWorkflowBtn.press("Enter");
-
-    const startNode = page.locator('[data-node-type="start"]');
-    await startNode.focus();
-
-    await expect(startNode).toBeVisible();
-    await expect(startNode).toBeFocused();
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 8. ARIA structural semantics
@@ -509,7 +518,9 @@ test.describe("ARIA structural semantics", () => {
     await expect(landmark).toBeAttached();
   });
 
-  test.fixme("property panel exposes a region landmark with an accessible label", async ({ page }) => {
+  test.fixme("property panel exposes a region landmark with an accessible label", async ({
+    page,
+  }) => {
     const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
     await newWorkflowBtn.press("Enter");
 

--- a/tests/e2e/quickstart-scenarios.spec.ts
+++ b/tests/e2e/quickstart-scenarios.spec.ts
@@ -360,23 +360,22 @@ test.describe("Quickstart Scenario 4: Diagnostics Flow", () => {
    *
    * Quickstart step: "Enter an invalid transition target."
    */
-  test.fixme(
-    "entering an invalid transition target triggers a diagnostics event",
-    async ({ page }) => {
-      await openEditor(page);
-      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-      await newWorkflowBtn.press("Enter");
+  test.fixme("entering an invalid transition target triggers a diagnostics event", async ({
+    page,
+  }) => {
+    await openEditor(page);
+    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+    await newWorkflowBtn.press("Enter");
 
-      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-      const transitionInput = panel
-        .locator('[aria-label*="transition" i], [data-field="transition"]')
-        .first();
-      await transitionInput.fill("__invalid_target__");
+    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+    const transitionInput = panel
+      .locator('[aria-label*="transition" i], [data-field="transition"]')
+      .first();
+    await transitionInput.fill("__invalid_target__");
 
-      const diagnosticsRegion = page.locator(DIAGNOSTICS_REGION_SELECTOR).first();
-      await expect(diagnosticsRegion).toBeAttached();
-    },
-  );
+    const diagnosticsRegion = page.locator(DIAGNOSTICS_REGION_SELECTOR).first();
+    await expect(diagnosticsRegion).toBeAttached();
+  });
 
   /**
    * Verifies that a node-level error indicator appears when an invalid
@@ -385,25 +384,22 @@ test.describe("Quickstart Scenario 4: Diagnostics Flow", () => {
    * Marked fixme: node error indicators are not yet rendered by the demo
    * harness.  Remove fixme once the graph node error UI lands.
    */
-  test.fixme(
-    "diagnostic error is reflected in local UI cues on the node",
-    async ({ page }) => {
-      await openEditor(page);
-      const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
-      await newWorkflowBtn.press("Enter");
+  test.fixme("diagnostic error is reflected in local UI cues on the node", async ({ page }) => {
+    await openEditor(page);
+    const newWorkflowBtn = page.locator(NEW_WORKFLOW_BUTTON_SELECTOR);
+    await newWorkflowBtn.press("Enter");
 
-      const panel = page.locator(PROPERTY_PANEL_SELECTOR);
-      const transitionInput = panel
-        .locator('[aria-label*="transition" i], [data-field="transition"]')
-        .first();
-      await transitionInput.fill("__invalid_target__");
+    const panel = page.locator(PROPERTY_PANEL_SELECTOR);
+    const transitionInput = panel
+      .locator('[aria-label*="transition" i], [data-field="transition"]')
+      .first();
+    await transitionInput.fill("__invalid_target__");
 
-      const errorIndicator = page
-        .locator('[data-testid="node-error"], [aria-label*="error" i]')
-        .first();
-      await expect(errorIndicator).toBeVisible();
-    },
-  );
+    const errorIndicator = page
+      .locator('[data-testid="node-error"], [aria-label*="error" i]')
+      .first();
+    await expect(errorIndicator).toBeVisible();
+  });
 
   /**
    * Verifies that explicit validation surfaces a global error summary.


### PR DESCRIPTION
## Summary

- Fixed TypeScript error TS4111 in `packages/editor-web-component/src/graph/insertion-ui.ts`: access `DOMStringMap` property via bracket notation (`item.dataset["taskTypeId"]`) per `noPropertyAccessFromIndexSignature` tsconfig rule
- Added `type="button"` to all `<button>` elements in `example/host-events/index.html` and `example/vanilla-js/index.html` to satisfy `lint/a11y/useButtonType`
- Applied Biome auto-fixes (import ordering and formatting) across example and test files

## Validation

- `pnpm --filter @sw-editor/example-e2e-harness build` ✅ clean Vite build
- `pnpm lint` ✅ 0 errors (111 files checked)
- `pnpm -r build` ✅ all 9 workspace packages build successfully
- `npx playwright test` ✅ 11 passed, 41 skipped (no failures)

Closes #177