### PR TITLE
feat(react-flow): import @xyflow/react stylesheet in renderer package

### DIFF
--- a/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
+++ b/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
@@ -10,6 +10,8 @@
  * @module
  */
 
+import "@xyflow/react/dist/style.css";
+
 import type {
   RendererAdapter,
   RendererCapabilitySnapshot,


### PR DESCRIPTION
## Summary

- Adds `import "@xyflow/react/dist/style.css"` to `packages/editor-renderer-react-flow/src/react-flow-adapter.ts`
- The stylesheet import lives in the renderer package so consumers automatically get the required styles
- Package builds without errors (`tsc --noEmit` passes)

## Test plan

- [ ] Run the harness with `?renderer=react-flow` and verify no "styles not loaded" React Flow warning appears in the console
- [ ] Confirm `pnpm --filter @sw-editor/editor-renderer-react-flow build` exits cleanly

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)