### PR TITLE
feat(e2e-harness): lazy-load rete-lit adapter to suppress Lit dev-mode warning

### DIFF
--- a/example/e2e-harness/main.ts
+++ b/example/e2e-harness/main.ts
@@ -26,7 +26,7 @@ import {
   validateWorkflow,
 } from "@sw-editor/editor-core";
 import { ReactFlowAdapter } from "@sw-editor/editor-host-client/react-flow";
-import { ReteLitAdapter } from "@sw-editor/editor-host-client/rete-lit";
+import type { ReteLitAdapter } from "@sw-editor/editor-host-client/rete-lit";
 
 // ---------------------------------------------------------------------------
 // Task type catalogue (mirrors InsertionUI.MVP_TASK_TYPES)
@@ -112,7 +112,7 @@ class SwEditorElement extends HTMLElement {
    * creates the renderer canvas, bootstraps the initial workflow graph, mounts
    * the renderer, and renders the first set of affordances.
    */
-  connectedCallback(): void {
+  async connectedCallback(): Promise<void> {
     // Create an inner div for the renderer canvas so the renderer's
     // overflow:hidden does not clip sibling elements (affordance buttons, task
     // menus) we append to `this`.
@@ -128,6 +128,7 @@ class SwEditorElement extends HTMLElement {
     if (renderer === "react-flow") {
       this.#adapter = new ReactFlowAdapter();
     } else {
+      const { ReteLitAdapter } = await import("@sw-editor/editor-host-client/rete-lit");
       this.#adapter = new ReteLitAdapter();
     }
     this.#adapter.mount(canvas, this.#graph);


### PR DESCRIPTION
## Summary

- Replace the static `import { ReteLitAdapter }` with `import type` (erased at build time) so Lit is never loaded as a side-effect
- Add a dynamic `import("@sw-editor/editor-host-client/rete-lit")` inside the `else` branch of `connectedCallback`, which only runs when `renderer !== "react-flow"`
- `connectedCallback` is made `async` to support the `await` inside the else branch

## Behaviour

- `?renderer=react-flow` — Lit module is never imported; no Lit dev-mode warning
- Default / `?renderer=rete-lit` — module is dynamically imported on demand; behaviour unchanged

## Test plan

- [ ] Visit harness with `?renderer=react-flow` — no Lit dev-mode warning in console
- [ ] Visit harness without query param (default rete-lit) — editor renders correctly
- [ ] `pnpm exec tsc --noEmit` passes (type-check confirmed clean)

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)