### PR TITLE
feat(react-flow): define and register custom node components

### DIFF
--- a/packages/editor-renderer-react-flow/src/index.ts
+++ b/packages/editor-renderer-react-flow/src/index.ts
@@ -17,4 +17,8 @@
  * adapter.dispose();
  * ```
  */
+
+export { EndNode, type EndNodeData } from "./nodes/EndNode.js";
+export { StartNode, type StartNodeData } from "./nodes/StartNode.js";
+export { TaskNode, type TaskNodeData } from "./nodes/TaskNode.js";
 export { ReactFlowAdapter } from "./react-flow-adapter.js";

--- a/packages/editor-renderer-react-flow/src/nodes/EndNode.tsx
+++ b/packages/editor-renderer-react-flow/src/nodes/EndNode.tsx
@@ -1,0 +1,48 @@
+/**
+ * React Flow custom node component for the `"end"` boundary node kind.
+ *
+ * Renders a labelled box with a single target {@link Handle} at the top,
+ * representing the terminal point of a workflow graph.
+ *
+ * @module
+ */
+
+import { Handle, type NodeProps, Position } from "@xyflow/react";
+// biome-ignore lint/style/useImportType: React is a value import required by jsx:"react" compilation
+import React from "react";
+
+/** Data shape carried by end nodes. */
+export interface EndNodeData {
+  /** The node kind discriminant. */
+  kind: "end";
+  [key: string]: unknown;
+}
+
+/**
+ * Visual component for an `"end"` boundary node.
+ *
+ * Renders a box labelled "End" with a target handle at the top so that
+ * React Flow can draw incoming edges to this node.
+ *
+ * @param _props - React Flow node props (position, selection state, etc.).
+ *   Data fields are not used for rendering at MVP quality.
+ * @returns A React element representing the end node.
+ */
+export function EndNode(_props: NodeProps): React.ReactElement {
+  return (
+    <div
+      style={{
+        padding: "8px 16px",
+        border: "2px solid #ef4444",
+        borderRadius: "4px",
+        background: "#fef2f2",
+        fontWeight: "bold",
+        textAlign: "center",
+        minWidth: "80px",
+      }}
+    >
+      <Handle type="target" position={Position.Top} />
+      End
+    </div>
+  );
+}

--- a/packages/editor-renderer-react-flow/src/nodes/StartNode.tsx
+++ b/packages/editor-renderer-react-flow/src/nodes/StartNode.tsx
@@ -1,0 +1,48 @@
+/**
+ * React Flow custom node component for the `"start"` boundary node kind.
+ *
+ * Renders a labelled box with a single source {@link Handle} at the bottom,
+ * representing the entry point of a workflow graph.
+ *
+ * @module
+ */
+
+import { Handle, type NodeProps, Position } from "@xyflow/react";
+// biome-ignore lint/style/useImportType: React is a value import required by jsx:"react" compilation
+import React from "react";
+
+/** Data shape carried by start nodes. */
+export interface StartNodeData {
+  /** The node kind discriminant. */
+  kind: "start";
+  [key: string]: unknown;
+}
+
+/**
+ * Visual component for a `"start"` boundary node.
+ *
+ * Renders a box labelled "Start" with a source handle at the bottom so that
+ * React Flow can draw outgoing edges from this node.
+ *
+ * @param _props - React Flow node props (position, selection state, etc.).
+ *   Data fields are not used for rendering at MVP quality.
+ * @returns A React element representing the start node.
+ */
+export function StartNode(_props: NodeProps): React.ReactElement {
+  return (
+    <div
+      style={{
+        padding: "8px 16px",
+        border: "2px solid #22c55e",
+        borderRadius: "4px",
+        background: "#f0fdf4",
+        fontWeight: "bold",
+        textAlign: "center",
+        minWidth: "80px",
+      }}
+    >
+      Start
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/packages/editor-renderer-react-flow/src/nodes/TaskNode.tsx
+++ b/packages/editor-renderer-react-flow/src/nodes/TaskNode.tsx
@@ -1,0 +1,53 @@
+/**
+ * React Flow custom node component for the `"task"` node kind.
+ *
+ * Renders a labelled box showing the task's `taskReference` value, with
+ * target and source {@link Handle} components for incoming and outgoing edges.
+ *
+ * @module
+ */
+
+import { Handle, type NodeProps, Position } from "@xyflow/react";
+// biome-ignore lint/style/useImportType: React is a value import required by jsx:"react" compilation
+import React from "react";
+
+/** Data shape carried by task nodes. */
+export interface TaskNodeData {
+  /** The node kind discriminant. */
+  kind: "task";
+  /** The workflow task reference name displayed as the node label. */
+  taskReference: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Visual component for a `"task"` workflow node.
+ *
+ * Renders a box labelled with the node's `taskReference` value. A target
+ * handle is placed at the top for incoming edges and a source handle at the
+ * bottom for outgoing edges.
+ *
+ * @param props - React Flow node props. `props.data.taskReference` is used as
+ *   the visible label; falls back to `"(task)"` when absent.
+ * @returns A React element representing the task node.
+ */
+export function TaskNode(props: NodeProps): React.ReactElement {
+  const data = props.data as TaskNodeData;
+  const label = data.taskReference ?? "(task)";
+  return (
+    <div
+      style={{
+        padding: "8px 16px",
+        border: "2px solid #3b82f6",
+        borderRadius: "4px",
+        background: "#eff6ff",
+        textAlign: "center",
+        minWidth: "100px",
+      }}
+    >
+      <Handle type="target" position={Position.Top} />
+      {label}
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
+++ b/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
@@ -23,12 +23,33 @@ import type {
 import {
   type Edge,
   type Node,
+  type NodeTypes,
   type OnSelectionChangeParams,
   ReactFlow,
   ReactFlowProvider,
 } from "@xyflow/react";
 import React, { useLayoutEffect, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { EndNode } from "./nodes/EndNode.js";
+import { StartNode } from "./nodes/StartNode.js";
+import { TaskNode } from "./nodes/TaskNode.js";
+
+// ---------------------------------------------------------------------------
+// Node type registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Mapping from workflow node kind strings to their React Flow custom component.
+ *
+ * Passed to the `<ReactFlow>` component so that it renders the correct visual
+ * representation for each node in the graph instead of the built-in default
+ * node shape.
+ */
+const nodeTypes: NodeTypes = {
+  start: StartNode,
+  end: EndNode,
+  task: TaskNode,
+};
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -189,6 +210,7 @@ function WorkflowFlowApp(props: WorkflowFlowAppProps): React.ReactElement {
     React.createElement(ReactFlow, {
       nodes,
       edges,
+      nodeTypes,
       onSelectionChange: props.onSelectionChange,
       fitView: true,
       proOptions: { hideAttribution: false },


### PR DESCRIPTION
## Summary

- Add `StartNode`, `EndNode`, and `TaskNode` React components in `packages/editor-renderer-react-flow/src/nodes/`
- Each component renders a labelled box with appropriate `Handle` connection points using React Flow's `Handle` and `Position` from `@xyflow/react`
- Build a `nodeTypes` map `{ start: StartNode, end: EndNode, task: TaskNode }` and pass it to `<ReactFlow>` in `WorkflowFlowApp`
- Re-export node components and their data interfaces from `src/index.ts`
- Package builds and type-checks without errors; biome lint passes clean

## Test plan

- [ ] Run harness with `?renderer=react-flow` and confirm no "Node type X not found" console warnings
- [ ] Verify start nodes render with a green border and a source handle at the bottom
- [ ] Verify end nodes render with a red border and a target handle at the top
- [ ] Verify task nodes render with a blue border, `taskReference` label, and handles at top/bottom
- [ ] `pnpm run build` in `packages/editor-renderer-react-flow` exits with code 0

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)