### PR TITLE
test(e2e): verify react-flow smoke test passes with no runtime warnings

### DIFF
--- a/tests/e2e/react-flow-renderer.spec.ts
+++ b/tests/e2e/react-flow-renderer.spec.ts
@@ -2,8 +2,15 @@
  * Smoke test for the React Flow renderer backend.
  *
  * Navigates to `/?renderer=react-flow`, verifies the harness loads without
- * uncaught JavaScript errors, inserts a task, and asserts that a
- * `[data-testid="graph-node"]` marker is visible in the DOM.
+ * uncaught JavaScript errors or known runtime warnings, inserts a task, and
+ * asserts that a `[data-testid="graph-node"]` marker is visible in the DOM.
+ *
+ * The test also guards against the three warning categories that were fixed
+ * in the preceding tasks:
+ * - Lit dev-mode warning (fired when the rete-lit adapter is eagerly imported)
+ * - React Flow "styles not loaded" warning (fixed by importing the stylesheet)
+ * - React Flow "Node type X not found" warnings (fixed by registering custom
+ *   node components for `start`, `end`, and `task`)
  *
  * @module
  */
@@ -11,18 +18,86 @@
 import { expect, type Page, test } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
+// Known warning patterns to assert absent
+// ---------------------------------------------------------------------------
+
+/**
+ * Substring patterns for console warnings that must NOT appear when the React
+ * Flow renderer is active.  Each entry describes the warning source so that
+ * assertion failure messages are informative.
+ */
+const FORBIDDEN_WARNING_PATTERNS: Array<{ label: string; substring: string }> = [
+  {
+    label: "Lit dev-mode warning",
+    substring: "Lit is in dev mode",
+  },
+  {
+    label: "React Flow styles-not-loaded warning",
+    substring: "It looks like you haven't loaded the styles",
+  },
+  {
+    label: "React Flow 'Node type not found' warning for start",
+    substring: "Node type \"start\" not found",
+  },
+  {
+    label: "React Flow 'Node type not found' warning for end",
+    substring: "Node type \"end\" not found",
+  },
+  {
+    label: "React Flow 'Node type not found' warning for task",
+    substring: "Node type \"task\" not found",
+  },
+];
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /**
- * Navigates to the editor host page with the react-flow renderer selected and
- * waits for the `sw-editor` custom element to mount.
+ * Navigates to the editor host page with the react-flow renderer selected,
+ * waits for the `sw-editor` custom element to mount, and returns a list of
+ * console warning messages collected during navigation.
  *
  * @param page - The Playwright {@link Page} object.
+ * @returns An object containing `errors` (uncaught JS errors) and `warnings`
+ *   (browser console warning messages) collected during page load.
  */
-async function openEditorWithReactFlow(page: Page): Promise<void> {
+async function openEditorWithReactFlow(
+  page: Page,
+): Promise<{ errors: string[]; warnings: string[] }> {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  page.on("pageerror", (err) => {
+    errors.push(err.message);
+  });
+
+  page.on("console", (msg) => {
+    if (msg.type() === "warning" || msg.type() === "error") {
+      warnings.push(msg.text());
+    }
+  });
+
   await page.goto("/?renderer=react-flow");
   await page.waitForSelector("sw-editor", { state: "attached" });
+
+  return { errors, warnings };
+}
+
+/**
+ * Asserts that none of the {@link FORBIDDEN_WARNING_PATTERNS} appear in the
+ * collected console messages.
+ *
+ * @param warnings - Console warning/error strings collected during the test.
+ */
+function assertNoForbiddenWarnings(warnings: string[]): void {
+  for (const { label, substring } of FORBIDDEN_WARNING_PATTERNS) {
+    const matched = warnings.filter((w) => w.includes(substring));
+    expect(
+      matched,
+      `${label} must not appear in console. Matched messages: ${matched.join("; ")}`,
+    ).toHaveLength(0);
+  }
 }
 
 /**
@@ -49,20 +124,18 @@ async function insertFirstTask(page: Page): Promise<void> {
 test.describe("React Flow renderer smoke test", () => {
   /**
    * Verifies that navigating to `/?renderer=react-flow` attaches the
-   * `sw-editor` custom element and produces no uncaught JavaScript errors.
+   * `sw-editor` custom element and produces no uncaught JavaScript errors or
+   * known runtime warnings (Lit dev-mode, React Flow styles, node type misses).
    */
   test("loads without uncaught JavaScript errors", async ({ page }) => {
-    const errors: string[] = [];
-    page.on("pageerror", (err) => {
-      errors.push(err.message);
-    });
-
-    await openEditorWithReactFlow(page);
+    const { errors, warnings } = await openEditorWithReactFlow(page);
 
     expect(
       errors,
       `Unexpected uncaught JS errors on load: ${errors.join("; ")}`,
     ).toHaveLength(0);
+
+    assertNoForbiddenWarnings(warnings);
 
     await expect(page.locator("sw-editor")).toBeAttached();
   });
@@ -70,15 +143,12 @@ test.describe("React Flow renderer smoke test", () => {
   /**
    * Verifies that inserting a task via the affordance UI causes a
    * `[data-testid="graph-node"]` marker to become visible, confirming that
-   * the React Flow renderer backend processes the graph update correctly.
+   * the React Flow renderer backend processes the graph update correctly and
+   * that no runtime warnings appear after the update.
    */
   test("graph node is visible after task insert", async ({ page }) => {
-    const errors: string[] = [];
-    page.on("pageerror", (err) => {
-      errors.push(err.message);
-    });
+    const { errors, warnings } = await openEditorWithReactFlow(page);
 
-    await openEditorWithReactFlow(page);
     await insertFirstTask(page);
 
     await expect(page.locator('[data-testid="graph-node"]').first()).toBeVisible();
@@ -87,5 +157,7 @@ test.describe("React Flow renderer smoke test", () => {
       errors,
       `Unexpected uncaught JS errors after task insert: ${errors.join("; ")}`,
     ).toHaveLength(0);
+
+    assertNoForbiddenWarnings(warnings);
   });
 });


### PR DESCRIPTION
## Summary

- Enhances the existing React Flow renderer smoke test (`tests/e2e/react-flow-renderer.spec.ts`) to explicitly assert the absence of the three warning categories fixed in the preceding tasks (#187, #188, #189):
  - **Lit dev-mode warning** — would fire if the rete-lit adapter was eagerly imported
  - **React Flow "styles not loaded" warning** — fixed by importing `@xyflow/react/dist/style.css`
  - **React Flow "Node type X not found" warnings** — fixed by registering `StartNode`, `EndNode`, and `TaskNode` custom components
- Refactors the page-setup helper to collect both uncaught JS errors and console warnings in a single pass, keeping both tests consistent
- Both tests pass; no runtime warnings are emitted when using `?renderer=react-flow`

## Test plan

- [x] `pnpm --filter @sw-editor/example-e2e-harness build` succeeds
- [x] `npx playwright test tests/e2e/react-flow-renderer.spec.ts` — 2 passed
- [x] No Lit dev-mode warning captured in console
- [x] No React Flow "styles not loaded" warning captured in console
- [x] No "Node type not found" warnings for `start`, `end`, or `task`
- [x] `[data-testid="graph-node"]` marker visible after task insert

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)