### PR TITLE
fix(editor-host-client): add jsx compiler option to tsconfig

### DIFF
--- a/packages/editor-host-client/tsconfig.json
+++ b/packages/editor-host-client/tsconfig.json
@@ -3,7 +3,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "jsx": "react"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Added `"jsx": "react"` to `compilerOptions` in `packages/editor-host-client/tsconfig.json`
- Fixes TypeScript error TS6142 when resolving `.tsx` files imported from `editor-renderer-react-flow`
- Matches the JSX mode used by `editor-renderer-react-flow` (`React.createElement`)

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)