### PR TITLE
feat(tests): create integration test helpers for insertion-layout

### DIFF
--- a/tests/integration/insertion-layout-helpers.spec.ts
+++ b/tests/integration/insertion-layout-helpers.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Smoke tests for insertion-layout integration test helpers.
+ *
+ * Verifies that the shared helper functions compile and behave correctly
+ * with real fixtures and graph operations.
+ *
+ * @module
+ */
+
+import { INITIAL_EDGE_ID, START_NODE_ID, END_NODE_ID } from "@sw-editor/editor-core";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertNodeOrder,
+  createEmptyGraph,
+  createRevisionCounter,
+  insertTaskAtEdge,
+  loadFixtureGraph,
+} from "./insertion-layout.helpers.js";
+
+describe("insertion-layout helpers (smoke)", () => {
+  it("loadFixtureGraph returns a graph with start and end nodes for simple.json", () => {
+    const graph = loadFixtureGraph("simple.json");
+
+    expect(graph.nodes.length).toBeGreaterThanOrEqual(2);
+    expect(graph.nodes[0]?.id).toBe(START_NODE_ID);
+    expect(graph.nodes[graph.nodes.length - 1]?.id).toBe(END_NODE_ID);
+    expect(graph.edges.length).toBeGreaterThan(0);
+  });
+
+  it("loadFixtureGraph returns correct node count for multi-task.json", () => {
+    const graph = loadFixtureGraph("multi-task.json");
+
+    // multi-task has 3 tasks + start + end = 5 nodes
+    expect(graph.nodes.length).toBe(5);
+  });
+
+  it("assertNodeOrder passes for correct ordering", () => {
+    const graph = createEmptyGraph();
+
+    // Should not throw
+    assertNodeOrder(graph, [START_NODE_ID, END_NODE_ID]);
+  });
+
+  it("assertNodeOrder throws for incorrect ordering", () => {
+    const graph = createEmptyGraph();
+
+    expect(() => assertNodeOrder(graph, [END_NODE_ID, START_NODE_ID])).toThrow(
+      "assertNodeOrder: mismatch at index 0",
+    );
+  });
+
+  it("assertNodeOrder throws for wrong length", () => {
+    const graph = createEmptyGraph();
+
+    expect(() => assertNodeOrder(graph, [START_NODE_ID])).toThrow(
+      "assertNodeOrder: expected 1 nodes but got 2",
+    );
+  });
+
+  it("insertTaskAtEdge splits the initial edge in an empty graph", () => {
+    const graph = createEmptyGraph();
+    const result = insertTaskAtEdge(graph, INITIAL_EDGE_ID);
+
+    // New graph should have 3 nodes: start, end, and the new task
+    expect(result.graph.nodes.length).toBe(3);
+    expect(result.nodeId).toMatch(/^task-/);
+    expect(result.revision).toBe(1);
+
+    // The initial edge should be replaced by two new edges
+    expect(result.graph.edges.length).toBe(2);
+    const edgeIds = result.graph.edges.map((e) => e.id);
+    expect(edgeIds).toContain(`${START_NODE_ID}->${result.nodeId}`);
+    expect(edgeIds).toContain(`${result.nodeId}->${END_NODE_ID}`);
+  });
+
+  it("createRevisionCounter starts at 0", () => {
+    const counter = createRevisionCounter();
+
+    expect(counter.currentRevision).toBe(0);
+    expect(counter.increment()).toBe(1);
+  });
+});

--- a/tests/integration/insertion-layout.helpers.ts
+++ b/tests/integration/insertion-layout.helpers.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared test helpers for insertion-layout integration tests.
+ *
+ * Provides utilities to load fixture workflows, build graphs, insert tasks,
+ * and assert node ordering — used across multiple insertion-layout test files.
+ *
+ * @module
+ */
+
+import { readFileSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  type InsertTaskResult,
+  RevisionCounter,
+  type WorkflowGraph,
+  type WorkflowSource,
+  bootstrapWorkflowGraph,
+  insertTask,
+  loadWorkflow,
+  projectWorkflowToGraph,
+  parseWorkflowSource,
+} from "@sw-editor/editor-core";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FIXTURES_DIR = resolve(fileURLToPath(new URL(".", import.meta.url)), "../fixtures/valid");
+
+// ---------------------------------------------------------------------------
+// Fixture loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Loads a fixture file by name, parses it into a workflow model, and projects
+ * it to a {@link WorkflowGraph}.
+ *
+ * @param fixtureName - File name relative to the `tests/fixtures/valid/`
+ *   directory (e.g. `"simple.json"` or `"multi-task.yaml"`).
+ * @returns The projected {@link WorkflowGraph} for the fixture.
+ * @throws If the fixture cannot be read, parsed, or projected.
+ */
+export function loadFixtureGraph(fixtureName: string): WorkflowGraph {
+  const filePath = resolve(FIXTURES_DIR, fixtureName);
+  const content = readFileSync(filePath, "utf-8");
+
+  const ext = extname(fixtureName).toLowerCase();
+  const format: "json" | "yaml" = ext === ".json" ? "json" : "yaml";
+
+  const source: WorkflowSource = { format, content };
+  const parseResult = parseWorkflowSource(source);
+
+  if (!parseResult.ok) {
+    const messages = parseResult.diagnostics.map((d) => d.message).join("; ");
+    throw new Error(`loadFixtureGraph: fixture "${fixtureName}" failed to parse: ${messages}`);
+  }
+
+  return projectWorkflowToGraph(parseResult.workflow);
+}
+
+// ---------------------------------------------------------------------------
+// Node ordering assertion
+// ---------------------------------------------------------------------------
+
+/**
+ * Asserts that the node IDs in a graph appear in the expected order.
+ *
+ * Compares only the `id` field of each node in the graph's `nodes` array
+ * against the provided expected IDs. The comparison is order-sensitive and
+ * the arrays must have the same length.
+ *
+ * @param graph - The workflow graph to inspect.
+ * @param expectedIds - Expected node IDs in their expected order.
+ * @throws If the actual node IDs do not match the expected IDs in order.
+ */
+export function assertNodeOrder(graph: WorkflowGraph, expectedIds: string[]): void {
+  const actualIds = graph.nodes.map((n) => n.id);
+  if (actualIds.length !== expectedIds.length) {
+    throw new Error(
+      `assertNodeOrder: expected ${expectedIds.length} nodes but got ${actualIds.length}.\n` +
+        `  Expected: [${expectedIds.join(", ")}]\n` +
+        `  Actual:   [${actualIds.join(", ")}]`,
+    );
+  }
+  for (let i = 0; i < expectedIds.length; i++) {
+    if (actualIds[i] !== expectedIds[i]) {
+      throw new Error(
+        `assertNodeOrder: mismatch at index ${i}.\n` +
+          `  Expected: "${expectedIds[i]}"\n` +
+          `  Actual:   "${actualIds[i]}"\n` +
+          `  Full expected: [${expectedIds.join(", ")}]\n` +
+          `  Full actual:   [${actualIds.join(", ")}]`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Insert task helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Inserts a task at the specified edge in the graph and returns the result.
+ *
+ * Creates a fresh {@link RevisionCounter} for each invocation so callers
+ * do not need to manage counter state.
+ *
+ * @param graph - The current workflow graph.
+ * @param edgeId - The ID of the edge to split for insertion.
+ * @param taskReference - Optional task reference for the new node.
+ * @returns The {@link InsertTaskResult} containing the updated graph, new
+ *   node ID, and revision number.
+ */
+export function insertTaskAtEdge(
+  graph: WorkflowGraph,
+  edgeId: string,
+  taskReference?: string,
+): InsertTaskResult {
+  const counter = new RevisionCounter();
+  return insertTask(graph, counter, { edgeId, taskReference });
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a fresh bootstrapped workflow graph (start → end) suitable for
+ * test setup.
+ *
+ * @returns A new {@link WorkflowGraph} with only the synthetic start and end
+ *   nodes connected by the initial edge.
+ */
+export function createEmptyGraph(): WorkflowGraph {
+  return bootstrapWorkflowGraph();
+}
+
+/**
+ * Creates a new {@link RevisionCounter} starting at revision 0.
+ *
+ * @returns A fresh revision counter.
+ */
+export function createRevisionCounter(): RevisionCounter {
+  return new RevisionCounter();
+}


### PR DESCRIPTION
## Summary

- Adds `tests/integration/insertion-layout.helpers.ts` with shared helper functions for insertion-layout integration tests:
  - `loadFixtureGraph()` — loads a fixture file, parses it, and projects to a `WorkflowGraph`
  - `assertNodeOrder()` — asserts node ID ordering in a graph
  - `insertTaskAtEdge()` — inserts a task at a given edge and returns the updated graph
  - `createEmptyGraph()` / `createRevisionCounter()` — setup utilities
- Adds `tests/integration/insertion-layout-helpers.spec.ts` smoke test confirming all helpers compile and work (7 passing tests)

Closes #209

## Test plan

- [x] All 7 smoke tests pass via `vitest run`
- [x] TypeScript compiles without errors (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)