### PR TITLE
feat(editor-renderer-contract): add RendererEdgeAnchor and FocusTarget types

### DIFF
--- a/packages/editor-renderer-contract/src/index.ts
+++ b/packages/editor-renderer-contract/src/index.ts
@@ -1,7 +1,9 @@
 export type {
+  FocusTarget,
   RendererAdapter,
   RendererCapabilitySnapshot,
   RendererClearSelection,
+  RendererEdgeAnchor,
   RendererEdgeSelection,
   RendererEventBridge,
   RendererGraphEdge,

--- a/packages/editor-renderer-contract/src/renderer-adapter.ts
+++ b/packages/editor-renderer-contract/src/renderer-adapter.ts
@@ -146,6 +146,45 @@ export interface RendererCapabilitySnapshot {
 }
 
 // ---------------------------------------------------------------------------
+// Edge anchor / focus target
+// ---------------------------------------------------------------------------
+
+/**
+ * A visual anchor point on a rendered edge, typically used to position an
+ * insertion control at the midpoint of an edge.
+ */
+export interface RendererEdgeAnchor {
+  /** Identity of the edge this anchor belongs to. */
+  edgeId: string;
+  /** Identity of the source node of the edge. */
+  sourceNodeId: string;
+  /** Identity of the target node of the edge. */
+  targetNodeId: string;
+  /** Horizontal coordinate of the anchor point in the renderer viewport (pixels). */
+  x: number;
+  /** Vertical coordinate of the anchor point in the renderer viewport (pixels). */
+  y: number;
+}
+
+/**
+ * Describes how the renderer should bring a node into view after insertion.
+ */
+export interface FocusTarget {
+  /** Identity of the node to focus. */
+  nodeId: string;
+  /**
+   * Optional scroll/zoom behavior hint.
+   *
+   * - `"center"` — scroll and zoom so the node is centered in the viewport.
+   * - `"ensure-visible"` — scroll the minimum amount needed to make the node
+   *   visible without changing zoom.
+   *
+   * When omitted the renderer may choose its own default behavior.
+   */
+  behavior?: "center" | "ensure-visible";
+}
+
+// ---------------------------------------------------------------------------
 // Adapter interface
 // ---------------------------------------------------------------------------
 
@@ -217,4 +256,27 @@ export interface RendererAdapter {
    * `update` or `dispose` again after this point is a programming error.
    */
   dispose(): void;
+
+  /**
+   * Retrieve the visual anchor point for the given edge.
+   *
+   * Returns the midpoint coordinates and connected node IDs for the edge,
+   * or `null` if the edge is not currently rendered or the renderer does
+   * not support edge anchors.
+   *
+   * @param edgeId - The identity of the edge to query.
+   * @returns The edge anchor, or `null` if unavailable.
+   */
+  getEdgeAnchor?(edgeId: string): RendererEdgeAnchor | null;
+
+  /**
+   * Bring a node into view in the renderer viewport.
+   *
+   * Used after inserting a new node to ensure it is visible to the user.
+   * Renderers that do not support programmatic focus may implement this as
+   * a no-op.
+   *
+   * @param target - Describes which node to focus and the desired behavior.
+   */
+  focusNode?(target: FocusTarget): void;
 }


### PR DESCRIPTION
## Summary

- Adds `RendererEdgeAnchor` type representing a visual anchor point on a rendered edge (midpoint coordinates, edge ID, source/target node IDs)
- Adds `FocusTarget` type representing a post-insert focus request with optional `"center"` or `"ensure-visible"` behavior
- Adds optional `getEdgeAnchor` and `focusNode` method signatures to the `RendererAdapter` interface
- Exports both new types from the package barrel

Methods are optional (`?`) so existing adapter implementations (`ReactFlowAdapter`, `ReteLitAdapter`) remain compatible without changes.

Closes #210

## Test plan

- [x] `npx tsc -p packages/editor-renderer-contract/tsconfig.json --noEmit` passes with zero errors
- [x] Existing adapter implementations are unaffected (methods are optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)