### PR TITLE
test: add insert-layout test fixtures

### DIFF
--- a/tests/fixtures/valid/insert-layout-linear.json
+++ b/tests/fixtures/valid/insert-layout-linear.json
@@ -1,0 +1,28 @@
+{
+  "document": {
+    "dsl": "1.0.0",
+    "namespace": "fixtures",
+    "name": "insert-layout-linear",
+    "version": "1.0.0"
+  },
+  "do": [
+    {
+      "taskA": {
+        "call": "http",
+        "with": {
+          "method": "get",
+          "endpoint": "https://api.example.com/a"
+        }
+      }
+    },
+    {
+      "taskB": {
+        "call": "http",
+        "with": {
+          "method": "get",
+          "endpoint": "https://api.example.com/b"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/valid/insert-layout-start-end.json
+++ b/tests/fixtures/valid/insert-layout-start-end.json
@@ -1,0 +1,17 @@
+{
+  "document": {
+    "dsl": "1.0.0",
+    "namespace": "fixtures",
+    "name": "insert-layout-start-end",
+    "version": "1.0.0"
+  },
+  "do": [
+    {
+      "noop": {
+        "set": {
+          "x": 1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `tests/fixtures/valid/insert-layout-start-end.json` — minimal single-task workflow for testing boundary insertions between start and end nodes
- Add `tests/fixtures/valid/insert-layout-linear.json` — linear two-task workflow (start → A → B → end) for testing mid-sequence insertions
- Both fixtures are valid Serverless Workflow DSL 1.0 JSON and pass the existing round-trip test harness (24/24 scenarios, 100% pass rate)

Closes #208

## Test plan

- [x] Both files are valid JSON
- [x] Both pass `parseWorkflowSource` load phase
- [x] Both pass same-format (JSON→JSON) round-trip
- [x] Both pass cross-format (JSON→YAML) round-trip
- [x] Existing round-trip pass rate stays at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)