### PR TITLE
fix(editor-core): splice new node at sourceIndex+1 in insert-task

### DIFF
--- a/packages/editor-core/src/commands/insert-task.ts
+++ b/packages/editor-core/src/commands/insert-task.ts
@@ -97,8 +97,13 @@ export function insertTask(
     target: targetEdge.target,
   };
 
+  const sourceIndex = graph.nodes.findIndex((n) => n.id === targetEdge.source);
+  const insertIndex = sourceIndex === -1 ? graph.nodes.length : sourceIndex + 1;
+  const updatedNodes = [...graph.nodes];
+  updatedNodes.splice(insertIndex, 0, newNode);
+
   const updatedGraph: WorkflowGraph = {
-    nodes: [...graph.nodes, newNode],
+    nodes: updatedNodes,
     edges: [...graph.edges.filter((e) => e.id !== edgeId), edgeToSource, edgeToTarget],
   };
 


### PR DESCRIPTION
## Summary

- **Bug fix**: In `insert-task.ts`, the new task node was appended to the end of the `nodes` array via spread + push. Now it is spliced at `sourceIndex + 1` (immediately after the source/predecessor node), preserving correct layout ordering.
- Falls back to appending at the end if the source node is somehow not found in the array.

Closes #214

## Test plan

- [x] All 126 existing editor-core tests pass (including 21 insert-task tests)
- [x] Ordering tests from T005 and integration tests from T006 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)