### PR TITLE
test(insertion-ui): add renderer-anchor attachment tests

### DIFF
--- a/packages/editor-web-component/package.json
+++ b/packages/editor-web-component/package.json
@@ -16,6 +16,7 @@
     "@sw-editor/editor-host-client": "workspace:*"
   },
   "devDependencies": {
+    "@sw-editor/editor-renderer-contract": "workspace:*",
     "happy-dom": "^20.8.3",
     "typescript": "5.9.3",
     "vitest": "4.0.18"

--- a/packages/editor-web-component/tests/graph/insertion-ui.test.ts
+++ b/packages/editor-web-component/tests/graph/insertion-ui.test.ts
@@ -7,6 +7,7 @@ import type {
   WorkflowChangedPayload,
 } from "@sw-editor/editor-host-client";
 import { EditorEventName } from "@sw-editor/editor-host-client";
+import type { RendererAdapter, RendererEdgeAnchor } from "@sw-editor/editor-renderer-contract";
 import { describe, expect, it, vi } from "vitest";
 import { EventBridge } from "../../src/events/index.js";
 import type { FocusNodeCallback, SerializeGraphCallback } from "../../src/graph/insertion-ui.js";
@@ -40,6 +41,45 @@ function makeHarness(focusNode?: FocusNodeCallback) {
     focusNode,
   });
   return { graph, counter, eventTarget, bridge, container, ui };
+}
+
+/**
+ * Creates a minimal mock of the renderer adapter with stubbed
+ * `getEdgeAnchor` and `focusNode` methods.
+ */
+function makeMockRendererAdapter(
+  anchorOverride?: RendererEdgeAnchor | null,
+): Pick<RendererAdapter, "getEdgeAnchor" | "focusNode"> & {
+  getEdgeAnchor: ReturnType<typeof vi.fn>;
+  focusNode: ReturnType<typeof vi.fn>;
+} {
+  return {
+    getEdgeAnchor: vi.fn((_edgeId: string) => anchorOverride ?? null),
+    focusNode: vi.fn(),
+  };
+}
+
+/**
+ * Creates a test harness that passes a renderer adapter to InsertionUI,
+ * enabling renderer-anchor–based positioning and focus delegation.
+ */
+function makeHarnessWithAdapter(
+  adapter: Pick<RendererAdapter, "getEdgeAnchor" | "focusNode">,
+) {
+  const graph = bootstrapWorkflowGraph();
+  const counter = new RevisionCounter();
+  const eventTarget = new EventTarget();
+  const bridge = new EventBridge(eventTarget, "0.0.0");
+  const container = document.createElement("div");
+  const ui = new InsertionUI({
+    container,
+    bridge,
+    graph,
+    counter,
+    serializeGraph: makeSerializer(),
+    rendererAdapter: adapter as RendererAdapter,
+  });
+  return { graph, counter, eventTarget, bridge, container, ui, adapter };
 }
 
 describe("MVP_TASK_TYPES", () => {
@@ -315,6 +355,76 @@ describe("InsertionUI", () => {
       ui.dispose();
 
       expect(container.querySelector("[role='menu']")).toBeNull();
+    });
+  });
+
+  describe("renderer-anchor attachment", () => {
+    it("positions the affordance button using RendererEdgeAnchor coordinates", () => {
+      const anchor: RendererEdgeAnchor = {
+        edgeId: INITIAL_EDGE_ID,
+        sourceNodeId: "start",
+        targetNodeId: "end",
+        x: 150,
+        y: 250,
+      };
+      const adapter = makeMockRendererAdapter(anchor);
+      const { ui, container } = makeHarnessWithAdapter(adapter);
+
+      const el = document.createElement("div");
+      ui.attachToEdge(INITIAL_EDGE_ID, el);
+
+      const button = el.querySelector<HTMLButtonElement>("button.sw-insertion-affordance");
+      expect(button).not.toBeNull();
+
+      // The InsertionUI should query the adapter for the anchor position and
+      // apply the coordinates as inline styles on the affordance button.
+      expect(adapter.getEdgeAnchor).toHaveBeenCalledWith(INITIAL_EDGE_ID);
+      expect(button?.style.left).toBe("150px");
+      expect(button?.style.top).toBe("250px");
+    });
+
+    it("uses fallback positioning when getEdgeAnchor returns null", () => {
+      const adapter = makeMockRendererAdapter(null);
+      const { ui } = makeHarnessWithAdapter(adapter);
+
+      const el = document.createElement("div");
+      ui.attachToEdge(INITIAL_EDGE_ID, el);
+
+      const button = el.querySelector<HTMLButtonElement>("button.sw-insertion-affordance");
+      expect(button).not.toBeNull();
+
+      // When no anchor is available, the button should not have explicit
+      // coordinate-based positioning (falling back to CSS/layout defaults).
+      expect(adapter.getEdgeAnchor).toHaveBeenCalledWith(INITIAL_EDGE_ID);
+      expect(button?.style.left).toBe("");
+      expect(button?.style.top).toBe("");
+    });
+
+    it("invokes the adapter focusNode callback after insertion", async () => {
+      const anchor: RendererEdgeAnchor = {
+        edgeId: INITIAL_EDGE_ID,
+        sourceNodeId: "start",
+        targetNodeId: "end",
+        x: 100,
+        y: 200,
+      };
+      const adapter = makeMockRendererAdapter(anchor);
+      const { ui, container } = makeHarnessWithAdapter(adapter);
+
+      ui.activateInsertion(INITIAL_EDGE_ID);
+
+      // biome-ignore lint/style/noNonNullAssertion: activateInsertion always renders menu items
+      const firstItem = container.querySelector<HTMLButtonElement>("[role='menuitem']")!;
+      firstItem.click();
+
+      // Allow any microtasks to complete.
+      await Promise.resolve();
+
+      expect(adapter.focusNode).toHaveBeenCalledOnce();
+      // The adapter's focusNode receives a FocusTarget object with the new node ID.
+      const call = adapter.focusNode.mock.calls[0][0];
+      expect(call).toHaveProperty("nodeId");
+      expect(typeof call.nodeId).toBe("string");
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
         specifier: workspace:*
         version: link:../editor-host-client
     devDependencies:
+      '@sw-editor/editor-renderer-contract':
+        specifier: workspace:*
+        version: link:../editor-renderer-contract
       happy-dom:
         specifier: ^20.8.3
         version: 20.8.3


### PR DESCRIPTION
## Summary

- Add 3 new test cases to `insertion-ui.test.ts` verifying InsertionUI consumes renderer-provided edge anchors
- Tests mock `getEdgeAnchor` and `focusNode` on the renderer adapter
- Add `@sw-editor/editor-renderer-contract` as a devDependency for type imports
- All 3 new tests intentionally fail (red) pending T011 implementation; all 50 existing tests pass

## Test cases

1. **Anchor-based positioning** — verifies affordance button `left`/`top` styles match `RendererEdgeAnchor` coordinates
2. **Fallback positioning** — verifies no coordinate styles applied when `getEdgeAnchor` returns `null`
3. **Focus delegation** — verifies adapter `focusNode` is called with a `FocusTarget` after insertion

Closes #216

## Test plan

- [x] Existing 50 tests still pass
- [x] 3 new tests fail as expected (red phase before T011)

🤖 Generated with [Claude Code](https://claude.com/claude-code)