### PR TITLE
docs(editor-core): document ordered linear-flow semantics on WorkflowGraph.nodes

### DIFF
--- a/packages/editor-core/src/graph/types.ts
+++ b/packages/editor-core/src/graph/types.ts
@@ -51,7 +51,14 @@ export interface GraphEdge {
  * - Insert operations must preserve graph connectivity.
  */
 export interface WorkflowGraph {
-  /** Ordered list of graph nodes. */
+  /**
+   * Ordered list of graph nodes.
+   *
+   * **Ordering contract:** For linear flows the array order represents
+   * left-to-right visual layout order. Renderers derive node placement
+   * directly from array position, so insertion commands must splice new
+   * nodes at the correct index to maintain the expected visual sequence.
+   */
   nodes: GraphNode[];
   /** Ordered list of directed edges between nodes. */
   edges: GraphEdge[];


### PR DESCRIPTION
## Summary
- Added JSDoc documentation to the `nodes` property of `WorkflowGraph` in `packages/editor-core/src/graph/types.ts`
- Documents the semantic contract that array order represents left-to-right visual layout order for linear flows
- Explains that renderers derive node placement from array position and that insertion commands must maintain ordering
- No functional code changes

Closes #215

## Test plan
- [x] Verify only JSDoc comments were added (no functional changes)
- [x] Confirm the documentation accurately describes the ordering contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)