### PR TITLE
feat(editor-renderer-react-flow): implement midpoint edge anchors and post-insert focus

### DIFF
--- a/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
+++ b/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
@@ -13,8 +13,10 @@
 import "@xyflow/react/dist/style.css";
 
 import type {
+  FocusTarget,
   RendererAdapter,
   RendererCapabilitySnapshot,
+  RendererEdgeAnchor,
   RendererEventBridge,
   RendererGraphEdge,
   RendererGraphNode,
@@ -29,6 +31,7 @@ import {
   type OnSelectionChangeParams,
   ReactFlow,
   ReactFlowProvider,
+  useReactFlow,
 } from "@xyflow/react";
 import React, { useLayoutEffect, useState } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -74,6 +77,31 @@ interface FlowController {
    * @param edges - The updated array of React Flow edges.
    */
   updateGraph(nodes: RFNode[], edges: RFEdge[]): void;
+
+  /**
+   * Retrieve a rendered node by its ID.
+   *
+   * @param id - The node ID to look up.
+   * @returns The node object, or `undefined` if not found.
+   */
+  getNode(id: string): RFNode | undefined;
+
+  /**
+   * Retrieve a rendered edge by its ID.
+   *
+   * @param id - The edge ID to look up.
+   * @returns The edge object, or `undefined` if not found.
+   */
+  getEdge(id: string): RFEdge | undefined;
+
+  /**
+   * Center the viewport on the given coordinates.
+   *
+   * @param x - The x coordinate to center on.
+   * @param y - The y coordinate to center on.
+   * @param options - Optional zoom and duration settings.
+   */
+  setCenter(x: number, y: number, options?: { zoom?: number; duration?: number }): void;
 }
 
 /** Props for the internal {@link WorkflowFlowApp} component. */
@@ -178,6 +206,49 @@ function toRFGraph(graph: WorkflowGraph): {
 // ---------------------------------------------------------------------------
 
 /**
+ * Inner component rendered inside {@link ReactFlowProvider} so that the
+ * `useReactFlow` hook is available. Exposes an imperative controller back
+ * to the adapter.
+ *
+ * @param props - Component properties.
+ * @returns A React element containing the React Flow canvas.
+ */
+function WorkflowFlowInner(props: WorkflowFlowAppProps): React.ReactElement {
+  const [nodes, setNodes] = useState<RFNode[]>(props.initialNodes);
+  const [edges, setEdges] = useState<RFEdge[]>(props.initialEdges);
+  const reactFlowInstance = useReactFlow();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: empty deps array is intentional; controller is published once on mount
+  useLayoutEffect(() => {
+    props.onController({
+      updateGraph(newNodes: RFNode[], newEdges: RFEdge[]): void {
+        setNodes(newNodes);
+        setEdges(newEdges);
+      },
+      getNode(id: string): RFNode | undefined {
+        return reactFlowInstance.getNode(id);
+      },
+      getEdge(id: string): RFEdge | undefined {
+        return reactFlowInstance.getEdge(id);
+      },
+      setCenter(x: number, y: number, options?: { zoom?: number; duration?: number }): void {
+        reactFlowInstance.setCenter(x, y, options);
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return React.createElement(ReactFlow, {
+    nodes,
+    edges,
+    nodeTypes,
+    onSelectionChange: props.onSelectionChange,
+    fitView: true,
+    proOptions: { hideAttribution: false },
+  });
+}
+
+/**
  * Internal React component that renders the React Flow canvas.
  *
  * The component maintains its own nodes/edges state and exposes an imperative
@@ -188,35 +259,10 @@ function toRFGraph(graph: WorkflowGraph): {
  * @returns A React element containing the React Flow canvas wrapped in a provider.
  */
 function WorkflowFlowApp(props: WorkflowFlowAppProps): React.ReactElement {
-  const [nodes, setNodes] = useState<RFNode[]>(props.initialNodes);
-  const [edges, setEdges] = useState<RFEdge[]>(props.initialEdges);
-
-  // Expose an imperative controller to the adapter immediately after mount.
-  // Using useLayoutEffect ensures the controller is available before the
-  // browser has painted, which prevents a race between mount() returning and
-  // the first update() call arriving.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: empty deps array is intentional; controller is published once on mount
-  useLayoutEffect(() => {
-    props.onController({
-      updateGraph(newNodes: RFNode[], newEdges: RFEdge[]): void {
-        setNodes(newNodes);
-        setEdges(newEdges);
-      },
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   return React.createElement(
     ReactFlowProvider,
     null,
-    React.createElement(ReactFlow, {
-      nodes,
-      edges,
-      nodeTypes,
-      onSelectionChange: props.onSelectionChange,
-      fitView: true,
-      proOptions: { hideAttribution: false },
-    }),
+    React.createElement(WorkflowFlowInner, props),
   );
 }
 
@@ -349,6 +395,9 @@ export class ReactFlowAdapter implements RendererAdapter {
   /** Whether {@link dispose} has been called. */
   private disposed = false;
 
+  /** The most recently rendered workflow graph, used for edge lookups. */
+  private lastGraph: WorkflowGraph | null = null;
+
   /**
    * Attach the React Flow renderer to `container` and render the initial graph.
    *
@@ -368,6 +417,7 @@ export class ReactFlowAdapter implements RendererAdapter {
       throw new Error("ReactFlowAdapter: mount() called after dispose()");
     }
 
+    this.lastGraph = graph;
     const { nodes, edges } = toRFGraph(graph);
     this.root = createRoot(container);
 
@@ -407,8 +457,69 @@ export class ReactFlowAdapter implements RendererAdapter {
       throw new Error("ReactFlowAdapter: update() called before mount() completed");
     }
 
+    this.lastGraph = graph;
     const { nodes, edges } = toRFGraph(graph);
     this.controller.updateGraph(nodes, edges);
+  }
+
+  /**
+   * Retrieve the visual anchor point for the given edge.
+   *
+   * Computes the geometric midpoint between the source and target node
+   * positions in the rendered layout. Returns `null` if the edge is not
+   * found in the current graph or the adapter is not mounted.
+   *
+   * @param edgeId - The identity of the edge to query.
+   * @returns The edge anchor with midpoint coordinates, or `null` if unavailable.
+   */
+  getEdgeAnchor(edgeId: string): RendererEdgeAnchor | null {
+    if (this.disposed || this.controller === null || this.lastGraph === null) {
+      return null;
+    }
+
+    const edge = this.lastGraph.edges.find((e) => e.id === edgeId);
+    if (!edge) {
+      return null;
+    }
+
+    const sourceIndex = this.lastGraph.nodes.findIndex((n) => n.id === edge.source);
+    const targetIndex = this.lastGraph.nodes.findIndex((n) => n.id === edge.target);
+    if (sourceIndex < 0 || targetIndex < 0) {
+      return null;
+    }
+
+    const sourcePos = nodePosition(sourceIndex);
+    const targetPos = nodePosition(targetIndex);
+
+    return {
+      edgeId,
+      sourceNodeId: edge.source,
+      targetNodeId: edge.target,
+      x: (sourcePos.x + targetPos.x) / 2,
+      y: (sourcePos.y + targetPos.y) / 2,
+    };
+  }
+
+  /**
+   * Bring a node into view in the renderer viewport.
+   *
+   * Scrolls and zooms the viewport to center the target node. If the node
+   * is not found or the adapter is not mounted, this is a no-op.
+   *
+   * @param target - Describes which node to focus and the desired behavior.
+   */
+  focusNode(target: FocusTarget): void {
+    if (this.disposed || this.controller === null || this.lastGraph === null) {
+      return;
+    }
+
+    const nodeIndex = this.lastGraph.nodes.findIndex((n) => n.id === target.nodeId);
+    if (nodeIndex < 0) {
+      return;
+    }
+
+    const pos = nodePosition(nodeIndex);
+    this.controller.setCenter(pos.x, pos.y, { duration: 200 });
   }
 
   /**
@@ -425,6 +536,7 @@ export class ReactFlowAdapter implements RendererAdapter {
     this.disposed = true;
     this.events.offSelectionChange();
     this.controller = null;
+    this.lastGraph = null;
     if (this.root !== null) {
       this.root.unmount();
       this.root = null;

--- a/packages/editor-web-component/src/graph/insertion-ui.ts
+++ b/packages/editor-web-component/src/graph/insertion-ui.ts
@@ -1,6 +1,7 @@
 import type { RevisionCounter, WorkflowGraph } from "@sw-editor/editor-core";
 import { type InsertTaskOptions, type InsertTaskResult, insertTask } from "@sw-editor/editor-core";
 import type { WorkflowSource } from "@sw-editor/editor-host-client";
+import type { RendererAdapter } from "@sw-editor/editor-renderer-contract";
 import type { EventBridge } from "../events/bridge.js";
 
 // ---------------------------------------------------------------------------
@@ -106,6 +107,9 @@ export class InsertionUI {
   private readonly counter: RevisionCounter;
   private readonly serializeGraph: SerializeGraphCallback;
   private readonly focusNode: FocusNodeCallback | undefined;
+  private readonly rendererAdapter:
+    | Pick<RendererAdapter, "getEdgeAnchor" | "focusNode">
+    | undefined;
 
   /** Live graph reference; must be kept current by the host. */
   private graph: WorkflowGraph;
@@ -134,6 +138,8 @@ export class InsertionUI {
    *   to a {@link WorkflowSource} for the `workflowChanged` event payload.
    * @param options.focusNode - Optional renderer callback that moves DOM focus
    *   to the node with the given ID.
+   * @param options.rendererAdapter - Optional renderer adapter used for
+   *   edge anchor positioning and post-insertion focus delegation.
    */
   constructor(options: {
     container: HTMLElement;
@@ -142,6 +148,7 @@ export class InsertionUI {
     counter: RevisionCounter;
     serializeGraph: SerializeGraphCallback;
     focusNode?: FocusNodeCallback;
+    rendererAdapter?: Pick<RendererAdapter, "getEdgeAnchor" | "focusNode">;
   }) {
     this.container = options.container;
     this.bridge = options.bridge;
@@ -149,6 +156,7 @@ export class InsertionUI {
     this.counter = options.counter;
     this.serializeGraph = options.serializeGraph;
     this.focusNode = options.focusNode;
+    this.rendererAdapter = options.rendererAdapter;
   }
 
   // ---------------------------------------------------------------------------
@@ -173,6 +181,16 @@ export class InsertionUI {
     this.detachFromEdge(edgeId);
 
     const button = this.createAffordanceButton(edgeId);
+
+    // If a renderer adapter is available, query it for anchor positioning.
+    if (this.rendererAdapter?.getEdgeAnchor) {
+      const edgeAnchor = this.rendererAdapter.getEdgeAnchor(edgeId);
+      if (edgeAnchor) {
+        button.style.left = `${edgeAnchor.x}px`;
+        button.style.top = `${edgeAnchor.y}px`;
+      }
+    }
+
     anchor.appendChild(button);
     this.affordances.set(edgeId, button);
 
@@ -428,6 +446,9 @@ export class InsertionUI {
 
     // Move DOM focus to the new node so the user can immediately edit it
     // without lifting their hands from the keyboard (FR-005).
+    if (this.rendererAdapter?.focusNode) {
+      this.rendererAdapter.focusNode({ nodeId: result.nodeId, behavior: "center" });
+    }
     this.focusNode?.(result.nodeId);
   }
 }

--- a/packages/editor-web-component/tests/graph/insertion-ui.test.ts
+++ b/packages/editor-web-component/tests/graph/insertion-ui.test.ts
@@ -47,9 +47,10 @@ function makeHarness(focusNode?: FocusNodeCallback) {
  * Creates a minimal mock of the renderer adapter with stubbed
  * `getEdgeAnchor` and `focusNode` methods.
  */
-function makeMockRendererAdapter(
-  anchorOverride?: RendererEdgeAnchor | null,
-): Pick<RendererAdapter, "getEdgeAnchor" | "focusNode"> & {
+function makeMockRendererAdapter(anchorOverride?: RendererEdgeAnchor | null): Pick<
+  RendererAdapter,
+  "getEdgeAnchor" | "focusNode"
+> & {
   getEdgeAnchor: ReturnType<typeof vi.fn>;
   focusNode: ReturnType<typeof vi.fn>;
 } {
@@ -63,9 +64,7 @@ function makeMockRendererAdapter(
  * Creates a test harness that passes a renderer adapter to InsertionUI,
  * enabling renderer-anchor–based positioning and focus delegation.
  */
-function makeHarnessWithAdapter(
-  adapter: Pick<RendererAdapter, "getEdgeAnchor" | "focusNode">,
-) {
+function makeHarnessWithAdapter(adapter: Pick<RendererAdapter, "getEdgeAnchor" | "focusNode">) {
   const graph = bootstrapWorkflowGraph();
   const counter = new RevisionCounter();
   const eventTarget = new EventTarget();

--- a/tests/e2e/react-flow-renderer.spec.ts
+++ b/tests/e2e/react-flow-renderer.spec.ts
@@ -37,15 +37,15 @@ const FORBIDDEN_WARNING_PATTERNS: Array<{ label: string; substring: string }> = 
   },
   {
     label: "React Flow 'Node type not found' warning for start",
-    substring: "Node type \"start\" not found",
+    substring: 'Node type "start" not found',
   },
   {
     label: "React Flow 'Node type not found' warning for end",
-    substring: "Node type \"end\" not found",
+    substring: 'Node type "end" not found',
   },
   {
     label: "React Flow 'Node type not found' warning for task",
-    substring: "Node type \"task\" not found",
+    substring: 'Node type "task" not found',
   },
 ];
 
@@ -130,10 +130,7 @@ test.describe("React Flow renderer smoke test", () => {
   test("loads without uncaught JavaScript errors", async ({ page }) => {
     const { errors, warnings } = await openEditorWithReactFlow(page);
 
-    expect(
-      errors,
-      `Unexpected uncaught JS errors on load: ${errors.join("; ")}`,
-    ).toHaveLength(0);
+    expect(errors, `Unexpected uncaught JS errors on load: ${errors.join("; ")}`).toHaveLength(0);
 
     assertNoForbiddenWarnings(warnings);
 

--- a/tests/integration/insertion-layout-order.spec.ts
+++ b/tests/integration/insertion-layout-order.spec.ts
@@ -12,11 +12,7 @@
 import { END_NODE_ID, START_NODE_ID } from "@sw-editor/editor-core";
 import { describe, expect, it } from "vitest";
 
-import {
-  assertNodeOrder,
-  insertTaskAtEdge,
-  loadFixtureGraph,
-} from "./insertion-layout.helpers.js";
+import { assertNodeOrder, insertTaskAtEdge, loadFixtureGraph } from "./insertion-layout.helpers.js";
 
 describe("insertion-layout-order — US1: node ordering after insert", () => {
   // -------------------------------------------------------------------------
@@ -62,13 +58,7 @@ describe("insertion-layout-order — US1: node ordering after insert", () => {
       const result = insertTaskAtEdge(graph, edgeId, "middleTask");
 
       // The new node must appear between taskA and taskB
-      assertNodeOrder(result.graph, [
-        START_NODE_ID,
-        "taskA",
-        result.nodeId,
-        "taskB",
-        END_NODE_ID,
-      ]);
+      assertNodeOrder(result.graph, [START_NODE_ID, "taskA", result.nodeId, "taskB", END_NODE_ID]);
     });
 
     it("inserts at the beginning of a linear chain", () => {
@@ -78,13 +68,7 @@ describe("insertion-layout-order — US1: node ordering after insert", () => {
       const edgeId = `${START_NODE_ID}->taskA`;
       const result = insertTaskAtEdge(graph, edgeId, "firstTask");
 
-      assertNodeOrder(result.graph, [
-        START_NODE_ID,
-        result.nodeId,
-        "taskA",
-        "taskB",
-        END_NODE_ID,
-      ]);
+      assertNodeOrder(result.graph, [START_NODE_ID, result.nodeId, "taskA", "taskB", END_NODE_ID]);
     });
 
     it("inserts at the end of a linear chain", () => {
@@ -94,13 +78,7 @@ describe("insertion-layout-order — US1: node ordering after insert", () => {
       const edgeId = `taskB->${END_NODE_ID}`;
       const result = insertTaskAtEdge(graph, edgeId, "lastTask");
 
-      assertNodeOrder(result.graph, [
-        START_NODE_ID,
-        "taskA",
-        "taskB",
-        result.nodeId,
-        END_NODE_ID,
-      ]);
+      assertNodeOrder(result.graph, [START_NODE_ID, "taskA", "taskB", result.nodeId, END_NODE_ID]);
     });
   });
 

--- a/tests/integration/insertion-renderer-matrix.spec.ts
+++ b/tests/integration/insertion-renderer-matrix.spec.ts
@@ -71,24 +71,14 @@ vi.mock("rete-area-plugin", () => {
   }
   class AreaPlugin {
     use(_plugin: unknown): void {}
-    async translate(
-      _id: string,
-      _position: { x: number; y: number },
-    ): Promise<void> {}
+    async translate(_id: string, _position: { x: number; y: number }): Promise<void> {}
     destroy(): void {}
   }
   const AreaExtensions = {
-    selectableNodes: (
-      _area: unknown,
-      _selector: unknown,
-      _opts: unknown,
-    ): void => {},
+    selectableNodes: (_area: unknown, _selector: unknown, _opts: unknown): void => {},
     accumulateOnCtrl: () => ({}),
     simpleNodesOrder: (_area: unknown): void => {},
-    zoomAt: (
-      _area: unknown,
-      _nodes: unknown[],
-    ): Promise<void> => Promise.resolve(),
+    zoomAt: (_area: unknown, _nodes: unknown[]): Promise<void> => Promise.resolve(),
     Selector,
   };
   return { AreaPlugin, AreaExtensions };
@@ -310,11 +300,9 @@ describe("Insertion renderer matrix", () => {
         // Bootstrap an empty graph (start → end) and insert a task.
         const baseGraph = bootstrapWorkflowGraph();
         const counter = new RevisionCounter();
-        const { graph: updatedGraph, nodeId: newNodeId } = insertTask(
-          baseGraph,
-          counter,
-          { edgeId: INITIAL_EDGE_ID },
-        );
+        const { graph: updatedGraph, nodeId: newNodeId } = insertTask(baseGraph, counter, {
+          edgeId: INITIAL_EDGE_ID,
+        });
 
         // After insertion the graph has:
         //   __start__ (index 0) → newNode (index 1) → __end__ (index 2)
@@ -334,7 +322,7 @@ describe("Insertion renderer matrix", () => {
         // Compute the expected midpoint from the linear layout.
         const startIndex = updatedGraph.nodes.findIndex((n) => n.id === START_NODE_ID);
         const newNodeIndex = updatedGraph.nodes.findIndex((n) => n.id === newNodeId);
-        const expectedMidX = ((startIndex * NODE_H_GAP) + (newNodeIndex * NODE_H_GAP)) / 2;
+        const expectedMidX = (startIndex * NODE_H_GAP + newNodeIndex * NODE_H_GAP) / 2;
         const expectedMidY = 0;
 
         const dist = distance(anchor!.x, anchor!.y, expectedMidX, expectedMidY);
@@ -355,11 +343,9 @@ describe("Insertion renderer matrix", () => {
 
         const baseGraph = bootstrapWorkflowGraph();
         const counter = new RevisionCounter();
-        const { graph: updatedGraph, nodeId: newNodeId } = insertTask(
-          baseGraph,
-          counter,
-          { edgeId: INITIAL_EDGE_ID },
-        );
+        const { graph: updatedGraph, nodeId: newNodeId } = insertTask(baseGraph, counter, {
+          edgeId: INITIAL_EDGE_ID,
+        });
 
         // Query the edge anchor for the second edge (newNode → end).
         const secondEdge = updatedGraph.edges.find((e) => e.target === END_NODE_ID);
@@ -370,7 +356,7 @@ describe("Insertion renderer matrix", () => {
 
         const newNodeIndex = updatedGraph.nodes.findIndex((n) => n.id === newNodeId);
         const endIndex = updatedGraph.nodes.findIndex((n) => n.id === END_NODE_ID);
-        const expectedMidX = ((newNodeIndex * NODE_H_GAP) + (endIndex * NODE_H_GAP)) / 2;
+        const expectedMidX = (newNodeIndex * NODE_H_GAP + endIndex * NODE_H_GAP) / 2;
         const expectedMidY = 0;
 
         const dist = distance(anchor!.x, anchor!.y, expectedMidX, expectedMidY);
@@ -389,19 +375,15 @@ describe("Insertion renderer matrix", () => {
 
         const baseGraph = bootstrapWorkflowGraph();
         const counter = new RevisionCounter();
-        const { nodeId: newNodeId } = insertTask(
-          baseGraph,
-          counter,
-          { edgeId: INITIAL_EDGE_ID, taskReference: "focusTestTask" },
-        );
+        const { nodeId: newNodeId } = insertTask(baseGraph, counter, {
+          edgeId: INITIAL_EDGE_ID,
+          taskReference: "focusTestTask",
+        });
 
         // Simulate the post-insertion focus call that editor-core would make.
         stub.focusNode({ nodeId: newNodeId, behavior: "center" });
 
-        expect(
-          stub.lastFocusTarget,
-          "focusNode must have been called",
-        ).not.toBeNull();
+        expect(stub.lastFocusTarget, "focusNode must have been called").not.toBeNull();
         expect(stub.lastFocusTarget!.nodeId).toBe(newNodeId);
         expect(stub.lastFocusTarget!.behavior).toBe("center");
       });
@@ -412,11 +394,7 @@ describe("Insertion renderer matrix", () => {
 
         const baseGraph = bootstrapWorkflowGraph();
         const counter = new RevisionCounter();
-        const { nodeId: newNodeId } = insertTask(
-          baseGraph,
-          counter,
-          { edgeId: INITIAL_EDGE_ID },
-        );
+        const { nodeId: newNodeId } = insertTask(baseGraph, counter, { edgeId: INITIAL_EDGE_ID });
 
         stub.focusNode({ nodeId: newNodeId, behavior: "ensure-visible" });
 
@@ -467,14 +445,13 @@ describe("Insertion renderer matrix", () => {
 
           const srcIdx = second.graph.nodes.findIndex((n) => n.id === edge.source);
           const tgtIdx = second.graph.nodes.findIndex((n) => n.id === edge.target);
-          const expectedX = ((srcIdx * NODE_H_GAP) + (tgtIdx * NODE_H_GAP)) / 2;
+          const expectedX = (srcIdx * NODE_H_GAP + tgtIdx * NODE_H_GAP) / 2;
           const expectedY = 0;
 
           const dist = distance(anchor!.x, anchor!.y, expectedX, expectedY);
-          expect(
-            dist,
-            `Edge ${edge.id} anchor midpoint exceeds tolerance`,
-          ).toBeLessThanOrEqual(MIDPOINT_TOLERANCE_PX);
+          expect(dist, `Edge ${edge.id} anchor midpoint exceeds tolerance`).toBeLessThanOrEqual(
+            MIDPOINT_TOLERANCE_PX,
+          );
         }
 
         // Focus should target the second inserted node.


### PR DESCRIPTION
## Summary

- Implement `getEdgeAnchor(edgeId)` on `ReactFlowAdapter` to compute the geometric midpoint of an edge from its source/target node positions in the linear layout
- Implement `focusNode(target)` on `ReactFlowAdapter` to center the viewport on a target node via React Flow's `setCenter` API
- Refactor `WorkflowFlowApp` into `ReactFlowProvider` wrapper + `WorkflowFlowInner` component to enable `useReactFlow()` hook access
- Extend `FlowController` interface with `getNode`, `getEdge`, and `setCenter` methods
- Update `InsertionUI` in `editor-web-component` to accept an optional `rendererAdapter` for edge anchor positioning and post-insertion focus delegation

## Test plan

- [x] All 170 integration tests pass (including cross-renderer matrix tests from T010)
- [x] All 53 editor-web-component tests pass (including 3 new renderer-anchor attachment tests)
- [x] Build succeeds across all packages

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)