### PR TITLE
feat(editor-web-component): export renderer-backed insertion surface types

### DIFF
--- a/packages/editor-web-component/src/graph/index.ts
+++ b/packages/editor-web-component/src/graph/index.ts
@@ -17,3 +17,9 @@ export {
   InsertionUI,
   MVP_TASK_TYPES,
 } from "./insertion-ui.js";
+
+export type {
+  FocusTarget,
+  RendererAdapter,
+  RendererEdgeAnchor,
+} from "@sw-editor/editor-renderer-contract";


### PR DESCRIPTION
## Summary

- Re-exports `FocusTarget`, `RendererAdapter`, and `RendererEdgeAnchor` types from `editor-web-component/src/graph/index.ts` so host applications can consume the full renderer-backed insertion surface without importing from `@sw-editor/editor-renderer-contract` directly.

Closes #219

## Test plan

- [x] Package compiles without errors (`pnpm build` passes)
- [x] All 53 existing tests pass (`pnpm --filter @sw-editor/editor-web-component test`)
- [x] Existing exports unchanged — only new type re-exports added

🤖 Generated with [Claude Code](https://claude.com/claude-code)