### PR TITLE
fix: resolve all biome lint violations

### DIFF
--- a/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
+++ b/packages/editor-renderer-react-flow/src/react-flow-adapter.ts
@@ -164,7 +164,8 @@ function nodePosition(index: number): { x: number; y: number } {
 function computeLayoutPositions(graph: WorkflowGraph): Map<string, { x: number; y: number }> {
   const positions = new Map<string, { x: number; y: number }>();
   for (let i = 0; i < graph.nodes.length; i++) {
-    const node = graph.nodes[i]!;
+    const node = graph.nodes[i];
+    if (!node) continue;
     positions.set(node.id, nodePosition(i));
   }
   return positions;
@@ -224,7 +225,7 @@ function toRFGraph(graph: WorkflowGraph): {
 } {
   const positions = computeLayoutPositions(graph);
   return {
-    nodes: graph.nodes.map((n) => toRFNode(n, positions.get(n.id)!)),
+    nodes: graph.nodes.map((n) => toRFNode(n, positions.get(n.id) ?? { x: 0, y: 0 })),
     edges: graph.edges.map((e) => toRFEdge(e)),
     positions,
   };

--- a/packages/editor-web-component/src/graph/index.ts
+++ b/packages/editor-web-component/src/graph/index.ts
@@ -9,6 +9,11 @@
  */
 
 export type {
+  FocusTarget,
+  RendererAdapter,
+  RendererEdgeAnchor,
+} from "@sw-editor/editor-renderer-contract";
+export type {
   FocusNodeCallback,
   SerializeGraphCallback,
   TaskTypeDescriptor,
@@ -17,9 +22,3 @@ export {
   InsertionUI,
   MVP_TASK_TYPES,
 } from "./insertion-ui.js";
-
-export type {
-  FocusTarget,
-  RendererAdapter,
-  RendererEdgeAnchor,
-} from "@sw-editor/editor-renderer-contract";

--- a/packages/editor-web-component/src/graph/insertion-ui.ts
+++ b/packages/editor-web-component/src/graph/insertion-ui.ts
@@ -348,6 +348,7 @@ export class InsertionUI {
       item.setAttribute("aria-label", `Insert ${taskType.label}`);
       item.className = "sw-task-menu__item";
       item.textContent = taskType.label;
+      // biome-ignore lint/complexity/useLiteralKeys: TypeScript requires bracket notation for index signatures
       item.dataset["taskTypeId"] = taskType.id;
 
       item.addEventListener("click", () => {

--- a/packages/editor-web-component/tests/graph/insertion-ui.test.ts
+++ b/packages/editor-web-component/tests/graph/insertion-ui.test.ts
@@ -359,7 +359,7 @@ describe("InsertionUI", () => {
 
   describe("sequential insertion", () => {
     it("inserting twice produces two new edges with affordance buttons", async () => {
-      const { ui, container, eventTarget, graph } = makeHarness();
+      const { ui, container, eventTarget } = makeHarness();
 
       // --- First insertion on the initial edge ---
       ui.activateInsertion(INITIAL_EDGE_ID);
@@ -373,7 +373,7 @@ describe("InsertionUI", () => {
 
       // After the first insertion the original edge (__start__->__end__) is gone
       // and replaced by two new edges: __start__->task and task->__end__.
-      const graphAfterFirst = ui["graph"];
+      const graphAfterFirst = ui.graph;
       expect(graphAfterFirst.edges.length).toBe(2);
 
       // Attach affordances for the two new edges.
@@ -398,7 +398,7 @@ describe("InsertionUI", () => {
 
       // After the second insertion, graph should have 3 edges total
       // (edge1 was split into 2, plus edge2 is still present).
-      const graphAfterSecond = ui["graph"];
+      const graphAfterSecond = ui.graph;
       expect(graphAfterSecond.edges.length).toBe(3);
       // And the original edge1 should no longer exist.
       expect(graphAfterSecond.edges.find((e) => e.id === edge1.id)).toBeUndefined();
@@ -410,7 +410,13 @@ describe("InsertionUI", () => {
       // Return distinct anchor coordinates for each call so we can verify recalculation.
       adapter.getEdgeAnchor.mockImplementation((edgeId: string) => {
         callCount++;
-        return { edgeId, sourceNodeId: "s", targetNodeId: "t", x: callCount * 100, y: callCount * 50 };
+        return {
+          edgeId,
+          sourceNodeId: "s",
+          targetNodeId: "t",
+          x: callCount * 100,
+          y: callCount * 50,
+        };
       });
 
       const { ui, container, eventTarget } = makeHarnessWithAdapter(adapter);
@@ -425,7 +431,7 @@ describe("InsertionUI", () => {
       container.querySelector<HTMLButtonElement>("[role='menuitem']")!.click();
       await firstChanged;
 
-      const graphAfterFirst = ui["graph"];
+      const graphAfterFirst = ui.graph;
       const [edgeA, edgeB] = graphAfterFirst.edges;
 
       // Reset call count to track fresh anchor queries.
@@ -459,7 +465,7 @@ describe("InsertionUI", () => {
       container.querySelector<HTMLButtonElement>("[role='menuitem']")!.click();
       await secondChanged;
 
-      const graphAfterSecond = ui["graph"];
+      const graphAfterSecond = ui.graph;
       adapter.getEdgeAnchor.mockClear();
       callCount = 0;
 
@@ -504,7 +510,7 @@ describe("InsertionUI", () => {
       expect(initialAnchor.querySelector("button.sw-insertion-affordance")).toBeNull();
 
       // Attach the two new edges.
-      const graphAfter = ui["graph"];
+      const graphAfter = ui.graph;
       const anchors = graphAfter.edges.map((edge) => {
         const el = document.createElement("div");
         ui.attachToEdge(edge.id, el);
@@ -529,7 +535,7 @@ describe("InsertionUI", () => {
         y: 250,
       };
       const adapter = makeMockRendererAdapter(anchor);
-      const { ui, container } = makeHarnessWithAdapter(adapter);
+      const { ui } = makeHarnessWithAdapter(adapter);
 
       const el = document.createElement("div");
       ui.attachToEdge(INITIAL_EDGE_ID, el);

--- a/tests/e2e/accessibility-insert-layout.spec.ts
+++ b/tests/e2e/accessibility-insert-layout.spec.ts
@@ -73,282 +73,266 @@ async function createNewWorkflow(page: Page): Promise<void> {
 // 1. aria-label presence on insertion controls
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Insertion controls — aria-label presence", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    await createNewWorkflow(page);
+test.describe
+  .fixme("Insertion controls — aria-label presence", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      await createNewWorkflow(page);
+    });
+
+    test("insertion affordance button has aria-label='Insert task'", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await expect(affordance).toBeAttached();
+      await expect(affordance).toHaveAttribute("aria-label", "Insert task");
+    });
+
+    test("all insertion affordance buttons have aria-label", async ({ page }) => {
+      const affordances = page.locator(INSERTION_BUTTON_SELECTOR);
+      const count = await affordances.count();
+      expect(count, "At least one insertion affordance should exist").toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const btn = affordances.nth(i);
+        await expect(btn).toHaveAttribute("aria-label", "Insert task");
+      }
+    });
+
+    test("task type menu has aria-label when open", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const menu = page.locator(TASK_MENU_SELECTOR);
+      await expect(menu).toBeVisible();
+      await expect(menu).toHaveAttribute("aria-label", "Select task type to insert");
+    });
+
+    test("each task type menu item has a descriptive aria-label", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const items = page.locator(TASK_MENU_ITEM_SELECTOR);
+      const count = await items.count();
+      expect(count, "Menu should contain at least one task type").toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const item = items.nth(i);
+        const ariaLabel = await item.getAttribute("aria-label");
+        expect(
+          (ariaLabel ?? "").length,
+          `Menu item at index ${i} must have a non-empty aria-label`,
+        ).toBeGreaterThan(0);
+      }
+    });
+
+    test("task type menu has role='menu'", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const menu = page.locator(TASK_MENU_SELECTOR);
+      await expect(menu).toHaveAttribute("role", "menu");
+    });
+
+    test("task type menu items have role='menuitem'", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const items = page.locator(TASK_MENU_ITEM_SELECTOR);
+      const count = await items.count();
+      for (let i = 0; i < count; i++) {
+        await expect(items.nth(i)).toHaveAttribute("role", "menuitem");
+      }
+    });
   });
-
-  test("insertion affordance button has aria-label='Insert task'", async ({
-    page,
-  }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await expect(affordance).toBeAttached();
-    await expect(affordance).toHaveAttribute("aria-label", "Insert task");
-  });
-
-  test("all insertion affordance buttons have aria-label", async ({ page }) => {
-    const affordances = page.locator(INSERTION_BUTTON_SELECTOR);
-    const count = await affordances.count();
-    expect(count, "At least one insertion affordance should exist").toBeGreaterThan(0);
-
-    for (let i = 0; i < count; i++) {
-      const btn = affordances.nth(i);
-      await expect(btn).toHaveAttribute("aria-label", "Insert task");
-    }
-  });
-
-  test("task type menu has aria-label when open", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const menu = page.locator(TASK_MENU_SELECTOR);
-    await expect(menu).toBeVisible();
-    await expect(menu).toHaveAttribute(
-      "aria-label",
-      "Select task type to insert",
-    );
-  });
-
-  test("each task type menu item has a descriptive aria-label", async ({
-    page,
-  }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const items = page.locator(TASK_MENU_ITEM_SELECTOR);
-    const count = await items.count();
-    expect(count, "Menu should contain at least one task type").toBeGreaterThan(0);
-
-    for (let i = 0; i < count; i++) {
-      const item = items.nth(i);
-      const ariaLabel = await item.getAttribute("aria-label");
-      expect(
-        (ariaLabel ?? "").length,
-        `Menu item at index ${i} must have a non-empty aria-label`,
-      ).toBeGreaterThan(0);
-    }
-  });
-
-  test("task type menu has role='menu'", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const menu = page.locator(TASK_MENU_SELECTOR);
-    await expect(menu).toHaveAttribute("role", "menu");
-  });
-
-  test("task type menu items have role='menuitem'", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const items = page.locator(TASK_MENU_ITEM_SELECTOR);
-    const count = await items.count();
-    for (let i = 0; i < count; i++) {
-      await expect(items.nth(i)).toHaveAttribute("role", "menuitem");
-    }
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 2. Focus management — post-insertion focus timing
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Focus management — post-insertion focus", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    await createNewWorkflow(page);
+test.describe
+  .fixme("Focus management — post-insertion focus", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      await createNewWorkflow(page);
+    });
+
+    test("focus lands on newly inserted node within 500ms", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+
+      // Record time immediately before selecting the task type.
+      const startTime = Date.now();
+      await firstItem.press("Enter");
+
+      // Wait for a graph node to receive focus within the 500ms budget.
+      const graphNode = page.locator(GRAPH_NODE_SELECTOR).first();
+      await expect(graphNode).toBeFocused({ timeout: 500 });
+
+      const elapsed = Date.now() - startTime;
+      expect(
+        elapsed,
+        `Focus must land on the newly inserted node within 500ms (took ${elapsed}ms)`,
+      ).toBeLessThanOrEqual(500);
+    });
+
+    test("focus moves to new node, not back to the affordance", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      // After insertion, focus should NOT remain on the affordance.
+      await expect(affordance).not.toBeFocused();
+
+      // A graph node should have received focus instead.
+      const graphNode = page.locator(GRAPH_NODE_SELECTOR).first();
+      await expect(graphNode).toBeFocused({ timeout: 500 });
+    });
+
+    test("task type menu closes after selection", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const menu = page.locator(TASK_MENU_SELECTOR);
+      await expect(menu).toBeVisible();
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      // Menu must be dismissed after selection.
+      await expect(menu).not.toBeVisible();
+    });
   });
-
-  test("focus lands on newly inserted node within 500ms", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-
-    // Record time immediately before selecting the task type.
-    const startTime = Date.now();
-    await firstItem.press("Enter");
-
-    // Wait for a graph node to receive focus within the 500ms budget.
-    const graphNode = page.locator(GRAPH_NODE_SELECTOR).first();
-    await expect(graphNode).toBeFocused({ timeout: 500 });
-
-    const elapsed = Date.now() - startTime;
-    expect(
-      elapsed,
-      `Focus must land on the newly inserted node within 500ms (took ${elapsed}ms)`,
-    ).toBeLessThanOrEqual(500);
-  });
-
-  test("focus moves to new node, not back to the affordance", async ({
-    page,
-  }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    // After insertion, focus should NOT remain on the affordance.
-    await expect(affordance).not.toBeFocused();
-
-    // A graph node should have received focus instead.
-    const graphNode = page.locator(GRAPH_NODE_SELECTOR).first();
-    await expect(graphNode).toBeFocused({ timeout: 500 });
-  });
-
-  test("task type menu closes after selection", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const menu = page.locator(TASK_MENU_SELECTOR);
-    await expect(menu).toBeVisible();
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    // Menu must be dismissed after selection.
-    await expect(menu).not.toBeVisible();
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 3. Screen-reader announcements after insertion
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Screen-reader — insertion announcements", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    await createNewWorkflow(page);
+test.describe
+  .fixme("Screen-reader — insertion announcements", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      await createNewWorkflow(page);
+    });
+
+    test("ARIA live region exists in the editor DOM", async ({ page }) => {
+      const liveRegion = page.locator(LIVE_REGION_SELECTOR);
+      await expect(liveRegion).toBeAttached();
+    });
+
+    test("live region updates after task insertion", async ({ page }) => {
+      const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
+
+      // Capture text before insertion.
+      const textBefore = await liveRegion.textContent();
+
+      // Perform an insertion.
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await firstItem.press("Enter");
+
+      // The live region content should change to announce the insertion/selection.
+      await expect(liveRegion).not.toHaveText(textBefore ?? "");
+    });
+
+    test("live region uses aria-live='polite' or 'assertive'", async ({ page }) => {
+      const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
+      const ariaLive = await liveRegion.getAttribute("aria-live");
+      expect(["polite", "assertive"], "aria-live must be 'polite' or 'assertive'").toContain(
+        ariaLive,
+      );
+    });
   });
-
-  test("ARIA live region exists in the editor DOM", async ({ page }) => {
-    const liveRegion = page.locator(LIVE_REGION_SELECTOR);
-    await expect(liveRegion).toBeAttached();
-  });
-
-  test("live region updates after task insertion", async ({ page }) => {
-    const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
-
-    // Capture text before insertion.
-    const textBefore = await liveRegion.textContent();
-
-    // Perform an insertion.
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await firstItem.press("Enter");
-
-    // The live region content should change to announce the insertion/selection.
-    await expect(liveRegion).not.toHaveText(textBefore ?? "");
-  });
-
-  test("live region uses aria-live='polite' or 'assertive'", async ({
-    page,
-  }) => {
-    const liveRegion = page.locator(LIVE_REGION_SELECTOR).first();
-    const ariaLive = await liveRegion.getAttribute("aria-live");
-    expect(
-      ["polite", "assertive"],
-      "aria-live must be 'polite' or 'assertive'",
-    ).toContain(ariaLive);
-  });
-});
 
 // ---------------------------------------------------------------------------
 // 4. Tab order — insertion controls reachable via keyboard
 // ---------------------------------------------------------------------------
 
-test.describe.fixme("Keyboard tab order — insertion controls", () => {
-  test.beforeEach(async ({ page }) => {
-    await openEditor(page);
-    await createNewWorkflow(page);
-  });
+test.describe
+  .fixme("Keyboard tab order — insertion controls", () => {
+    test.beforeEach(async ({ page }) => {
+      await openEditor(page);
+      await createNewWorkflow(page);
+    });
 
-  test("insertion affordance is reachable via Tab navigation", async ({
-    page,
-  }) => {
-    // Tab through the page until the insertion affordance receives focus.
-    // Limit iterations to prevent infinite loops in case of focus trap issues.
-    const maxTabs = 50;
-    let reached = false;
+    test("insertion affordance is reachable via Tab navigation", async ({ page }) => {
+      // Tab through the page until the insertion affordance receives focus.
+      // Limit iterations to prevent infinite loops in case of focus trap issues.
+      const maxTabs = 50;
+      let reached = false;
 
-    for (let i = 0; i < maxTabs; i++) {
-      await page.keyboard.press("Tab");
+      for (let i = 0; i < maxTabs; i++) {
+        await page.keyboard.press("Tab");
 
-      const focused = page.locator(INSERTION_BUTTON_SELECTOR).first();
-      if (await focused.evaluate((el) => el === document.activeElement).catch(() => false)) {
-        reached = true;
-        break;
+        const focused = page.locator(INSERTION_BUTTON_SELECTOR).first();
+        if (await focused.evaluate((el) => el === document.activeElement).catch(() => false)) {
+          reached = true;
+          break;
+        }
       }
-    }
 
-    expect(
-      reached,
-      `Insertion affordance must be reachable via Tab within ${maxTabs} key presses`,
-    ).toBe(true);
+      expect(
+        reached,
+        `Insertion affordance must be reachable via Tab within ${maxTabs} key presses`,
+      ).toBe(true);
+    });
+
+    test("insertion affordance is focusable and activatable via Enter", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.focus();
+      await expect(affordance).toBeFocused();
+
+      await affordance.press("Enter");
+      const menu = page.locator(TASK_MENU_SELECTOR);
+      await expect(menu).toBeVisible();
+    });
+
+    test("insertion affordance is activatable via Space", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.focus();
+      await affordance.press(" ");
+
+      const menu = page.locator(TASK_MENU_SELECTOR);
+      await expect(menu).toBeVisible();
+    });
+
+    test("Escape from task menu returns focus to affordance", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
+
+      await page.keyboard.press("Escape");
+
+      await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
+      await expect(affordance).toBeFocused();
+    });
+
+    test("tab order progresses through menu items with ArrowDown", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await expect(firstItem).toBeFocused();
+
+      await page.keyboard.press("ArrowDown");
+
+      const secondItem = page.locator(TASK_MENU_ITEM_SELECTOR).nth(1);
+      await expect(secondItem).toBeFocused();
+    });
+
+    test("ArrowUp navigates back through menu items", async ({ page }) => {
+      const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
+      await affordance.press("Enter");
+
+      // Move down then back up.
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("ArrowUp");
+
+      const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
+      await expect(firstItem).toBeFocused();
+    });
   });
-
-  test("insertion affordance is focusable and activatable via Enter", async ({
-    page,
-  }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.focus();
-    await expect(affordance).toBeFocused();
-
-    await affordance.press("Enter");
-    const menu = page.locator(TASK_MENU_SELECTOR);
-    await expect(menu).toBeVisible();
-  });
-
-  test("insertion affordance is activatable via Space", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.focus();
-    await affordance.press(" ");
-
-    const menu = page.locator(TASK_MENU_SELECTOR);
-    await expect(menu).toBeVisible();
-  });
-
-  test("Escape from task menu returns focus to affordance", async ({
-    page,
-  }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
-
-    await page.keyboard.press("Escape");
-
-    await expect(page.locator(TASK_MENU_SELECTOR)).not.toBeVisible();
-    await expect(affordance).toBeFocused();
-  });
-
-  test("tab order progresses through menu items with ArrowDown", async ({
-    page,
-  }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await expect(firstItem).toBeFocused();
-
-    await page.keyboard.press("ArrowDown");
-
-    const secondItem = page.locator(TASK_MENU_ITEM_SELECTOR).nth(1);
-    await expect(secondItem).toBeFocused();
-  });
-
-  test("ArrowUp navigates back through menu items", async ({ page }) => {
-    const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
-    await affordance.press("Enter");
-
-    // Move down then back up.
-    await page.keyboard.press("ArrowDown");
-    await page.keyboard.press("ArrowUp");
-
-    const firstItem = page.locator(TASK_MENU_ITEM_SELECTOR).first();
-    await expect(firstItem).toBeFocused();
-  });
-});

--- a/tests/e2e/insert-layout-affordance.spec.ts
+++ b/tests/e2e/insert-layout-affordance.spec.ts
@@ -29,12 +29,10 @@ const INSERTION_BUTTON_SELECTOR = 'button[aria-label="Insert task"]';
 const NEW_WORKFLOW_BUTTON_SELECTOR = 'button[aria-label="Create new workflow"]';
 
 /** Task type selection menu opened by an insertion affordance. */
-const TASK_MENU_SELECTOR =
-  '[role="menu"][aria-label="Select task type to insert"]';
+const TASK_MENU_SELECTOR = '[role="menu"][aria-label="Select task type to insert"]';
 
 /** Canvas / viewport container used for pan/zoom interactions. */
-const CANVAS_SELECTOR =
-  '[data-testid="editor-canvas"], .react-flow__viewport, .react-flow';
+const CANVAS_SELECTOR = '[data-testid="editor-canvas"], .react-flow__viewport, .react-flow';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -78,10 +76,7 @@ async function createNewWorkflow(page: Page): Promise<void> {
  * @param selector - CSS selector for the target element.
  * @returns The `{ x, y }` center coordinates of the element bounding box.
  */
-async function getElementCenter(
-  page: Page,
-  selector: string,
-): Promise<{ x: number; y: number }> {
+async function _getElementCenter(page: Page, selector: string): Promise<{ x: number; y: number }> {
   const box = await page.locator(selector).first().boundingBox();
   if (!box) {
     throw new Error(`Element not found or not visible: ${selector}`);
@@ -95,13 +90,8 @@ async function getElementCenter(
  * @param page - The Playwright {@link Page} object.
  * @returns The `{ x, y }` center coordinates of the affordance button.
  */
-async function getAffordanceCenter(
-  page: Page,
-): Promise<{ x: number; y: number }> {
-  const box = await page
-    .locator(INSERTION_BUTTON_SELECTOR)
-    .first()
-    .boundingBox();
+async function getAffordanceCenter(page: Page): Promise<{ x: number; y: number }> {
+  const box = await page.locator(INSERTION_BUTTON_SELECTOR).first().boundingBox();
   if (!box) {
     throw new Error("Insertion affordance button not found or not visible");
   }
@@ -119,14 +109,10 @@ async function getAffordanceCenter(
  * @param page - The Playwright {@link Page} object.
  * @returns The `{ x, y }` midpoint between the source and target node centers.
  */
-async function getEdgeMidpoint(
-  page: Page,
-): Promise<{ x: number; y: number }> {
+async function getEdgeMidpoint(page: Page): Promise<{ x: number; y: number }> {
   // Retrieve edge endpoint node positions by locating start and end nodes.
   // In a new workflow, the initial graph has start → end with one edge.
-  const startNode = page.locator(
-    '[data-node-type="start"], [data-testid="graph-node"]',
-  );
+  const startNode = page.locator('[data-node-type="start"], [data-testid="graph-node"]');
   const endNode = page.locator('[data-node-type="end"]');
 
   const startBox = await startNode.first().boundingBox();
@@ -158,10 +144,7 @@ async function getEdgeMidpoint(
  * @param b - Second point.
  * @returns Distance in pixels.
  */
-function distance(
-  a: { x: number; y: number },
-  b: { x: number; y: number },
-): number {
+function distance(a: { x: number; y: number }, b: { x: number; y: number }): number {
   return Math.sqrt((a.x - b.x) ** 2 + (a.y - b.y) ** 2);
 }
 
@@ -169,17 +152,14 @@ function distance(
 // 1. Midpoint positioning
 // ---------------------------------------------------------------------------
 
-test.describe.fixme(
-  "Insertion affordance — midpoint positioning (US2, SC-002)",
-  () => {
+test.describe
+  .fixme("Insertion affordance — midpoint positioning (US2, SC-002)", () => {
     test.beforeEach(async ({ page }) => {
       await openEditor(page);
       await createNewWorkflow(page);
     });
 
-    test("'+' button is positioned within 12px of the edge midpoint", async ({
-      page,
-    }) => {
+    test("'+' button is positioned within 12px of the edge midpoint", async ({ page }) => {
       const affordanceCenter = await getAffordanceCenter(page);
       const midpoint = await getEdgeMidpoint(page);
 
@@ -192,15 +172,10 @@ test.describe.fixme(
       ).toBeLessThanOrEqual(MIDPOINT_TOLERANCE_PX);
     });
 
-    test("all insertion affordances are within 12px of their edge midpoints", async ({
-      page,
-    }) => {
+    test("all insertion affordances are within 12px of their edge midpoints", async ({ page }) => {
       const affordances = page.locator(INSERTION_BUTTON_SELECTOR);
       const count = await affordances.count();
-      expect(
-        count,
-        "At least one insertion affordance should exist",
-      ).toBeGreaterThan(0);
+      expect(count, "At least one insertion affordance should exist").toBeGreaterThan(0);
 
       for (let i = 0; i < count; i++) {
         const box = await affordances.nth(i).boundingBox();
@@ -212,28 +187,24 @@ test.describe.fixme(
         // A precise per-edge midpoint check requires edge-specific DOM
         // attributes that may vary by renderer; the primary midpoint assertion
         // is covered by the first test in this suite.
-        expect(box!.width, `Affordance ${i} should have non-zero width`).toBeGreaterThan(0);
-        expect(box!.height, `Affordance ${i} should have non-zero height`).toBeGreaterThan(0);
+        expect(box?.width, `Affordance ${i} should have non-zero width`).toBeGreaterThan(0);
+        expect(box?.height, `Affordance ${i} should have non-zero height`).toBeGreaterThan(0);
       }
     });
-  },
-);
+  });
 
 // ---------------------------------------------------------------------------
 // 2. Position stability after pan/zoom
 // ---------------------------------------------------------------------------
 
-test.describe.fixme(
-  "Insertion affordance — position after pan/zoom (US2)",
-  () => {
+test.describe
+  .fixme("Insertion affordance — position after pan/zoom (US2)", () => {
     test.beforeEach(async ({ page }) => {
       await openEditor(page);
       await createNewWorkflow(page);
     });
 
-    test("affordance remains within 12px of edge midpoint after pan", async ({
-      page,
-    }) => {
+    test("affordance remains within 12px of edge midpoint after pan", async ({ page }) => {
       // Record the initial relative offset between affordance and midpoint.
       const initialAffordance = await getAffordanceCenter(page);
       const initialMidpoint = await getEdgeMidpoint(page);
@@ -244,8 +215,8 @@ test.describe.fixme(
       const canvasBox = await canvas.boundingBox();
       expect(canvasBox, "Canvas element must be visible").not.toBeNull();
 
-      const startX = canvasBox!.x + canvasBox!.width / 2;
-      const startY = canvasBox!.y + canvasBox!.height / 2;
+      const startX = canvasBox?.x + canvasBox?.width / 2;
+      const startY = canvasBox?.y + canvasBox?.height / 2;
 
       await page.mouse.move(startX, startY);
       await page.mouse.down();
@@ -269,16 +240,14 @@ test.describe.fixme(
       ).toBeLessThanOrEqual(MIDPOINT_TOLERANCE_PX);
     });
 
-    test("affordance remains within 12px of edge midpoint after zoom", async ({
-      page,
-    }) => {
+    test("affordance remains within 12px of edge midpoint after zoom", async ({ page }) => {
       // Zoom in using Ctrl+wheel on the canvas.
       const canvas = page.locator(CANVAS_SELECTOR).first();
       const canvasBox = await canvas.boundingBox();
       expect(canvasBox, "Canvas element must be visible").not.toBeNull();
 
-      const centerX = canvasBox!.x + canvasBox!.width / 2;
-      const centerY = canvasBox!.y + canvasBox!.height / 2;
+      const centerX = canvasBox?.x + canvasBox?.width / 2;
+      const centerY = canvasBox?.y + canvasBox?.height / 2;
 
       await page.mouse.move(centerX, centerY);
       await page.mouse.wheel(0, -200);
@@ -304,8 +273,8 @@ test.describe.fixme(
       const canvasBox = await canvas.boundingBox();
       expect(canvasBox, "Canvas element must be visible").not.toBeNull();
 
-      const centerX = canvasBox!.x + canvasBox!.width / 2;
-      const centerY = canvasBox!.y + canvasBox!.height / 2;
+      const centerX = canvasBox?.x + canvasBox?.width / 2;
+      const centerY = canvasBox?.y + canvasBox?.height / 2;
 
       // Pan first.
       await page.mouse.move(centerX, centerY);
@@ -330,24 +299,20 @@ test.describe.fixme(
           `of edge midpoint (distance: ${dist.toFixed(1)}px)`,
       ).toBeLessThanOrEqual(MIDPOINT_TOLERANCE_PX);
     });
-  },
-);
+  });
 
 // ---------------------------------------------------------------------------
 // 3. Keyboard operability
 // ---------------------------------------------------------------------------
 
-test.describe.fixme(
-  "Insertion affordance — keyboard operability (US2)",
-  () => {
+test.describe
+  .fixme("Insertion affordance — keyboard operability (US2)", () => {
     test.beforeEach(async ({ page }) => {
       await openEditor(page);
       await createNewWorkflow(page);
     });
 
-    test("insertion affordance is reachable via Tab navigation", async ({
-      page,
-    }) => {
+    test("insertion affordance is reachable via Tab navigation", async ({ page }) => {
       const maxTabs = 50;
       let reached = false;
 
@@ -355,11 +320,7 @@ test.describe.fixme(
         await page.keyboard.press("Tab");
 
         const focused = page.locator(INSERTION_BUTTON_SELECTOR).first();
-        if (
-          await focused
-            .evaluate((el) => el === document.activeElement)
-            .catch(() => false)
-        ) {
+        if (await focused.evaluate((el) => el === document.activeElement).catch(() => false)) {
           reached = true;
           break;
         }
@@ -371,9 +332,7 @@ test.describe.fixme(
       ).toBe(true);
     });
 
-    test("Enter key activates the insertion menu from focused affordance", async ({
-      page,
-    }) => {
+    test("Enter key activates the insertion menu from focused affordance", async ({ page }) => {
       const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
       await affordance.focus();
       await expect(affordance).toBeFocused();
@@ -384,9 +343,7 @@ test.describe.fixme(
       await expect(menu).toBeVisible();
     });
 
-    test("Space key activates the insertion menu from focused affordance", async ({
-      page,
-    }) => {
+    test("Space key activates the insertion menu from focused affordance", async ({ page }) => {
       const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
       await affordance.focus();
       await expect(affordance).toBeFocused();
@@ -397,9 +354,7 @@ test.describe.fixme(
       await expect(menu).toBeVisible();
     });
 
-    test("Escape closes the menu and returns focus to the affordance", async ({
-      page,
-    }) => {
+    test("Escape closes the menu and returns focus to the affordance", async ({ page }) => {
       const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
       await affordance.press("Enter");
 
@@ -412,9 +367,7 @@ test.describe.fixme(
       await expect(affordance).toBeFocused();
     });
 
-    test("keyboard-activated insertion completes without mouse interaction", async ({
-      page,
-    }) => {
+    test("keyboard-activated insertion completes without mouse interaction", async ({ page }) => {
       // Tab to the affordance.
       const affordance = page.locator(INSERTION_BUTTON_SELECTOR).first();
       await affordance.focus();
@@ -431,5 +384,4 @@ test.describe.fixme(
       // The menu should close after selection.
       await expect(menu).not.toBeVisible();
     });
-  },
-);
+  });

--- a/tests/e2e/insert-layout-order.spec.ts
+++ b/tests/e2e/insert-layout-order.spec.ts
@@ -32,8 +32,7 @@ const NEW_WORKFLOW_BUTTON_SELECTOR = 'button[aria-label="Create new workflow"]';
 const INSERTION_BUTTON_SELECTOR = 'button[aria-label="Insert task"]';
 
 /** Task type selection menu opened by an insertion affordance. */
-const TASK_MENU_SELECTOR =
-  '[role="menu"][aria-label="Select task type to insert"]';
+const TASK_MENU_SELECTOR = '[role="menu"][aria-label="Select task type to insert"]';
 
 /** Individual task type entries within the open menu. */
 const TASK_MENU_ITEM_SELECTOR = '[role="menuitem"]';
@@ -78,9 +77,7 @@ async function insertTaskViaAffordance(
   affordanceIndex: number,
   menuItemIndex: number,
 ): Promise<void> {
-  const affordance = page
-    .locator(INSERTION_BUTTON_SELECTOR)
-    .nth(affordanceIndex);
+  const affordance = page.locator(INSERTION_BUTTON_SELECTOR).nth(affordanceIndex);
   await affordance.press("Enter");
 
   await expect(page.locator(TASK_MENU_SELECTOR)).toBeVisible();
@@ -102,9 +99,7 @@ test.describe("Insertion layout ordering (US1)", () => {
     await createNewWorkflow(page);
   });
 
-  test("inserted node appears in the graph between predecessor and successor", async ({
-    page,
-  }) => {
+  test("inserted node appears in the graph between predecessor and successor", async ({ page }) => {
     // Before insertion: the bootstrapped graph has start → end with one edge
     // and one insertion affordance. No task nodes exist yet.
     await expect(page.locator(GRAPH_NODE_SELECTOR)).toHaveCount(0);
@@ -134,9 +129,7 @@ test.describe("Insertion layout ordering (US1)", () => {
     await expect(affordances).toHaveCount(2);
   });
 
-  test("DOM order of graph-node markers matches insertion sequence", async ({
-    page,
-  }) => {
+  test("DOM order of graph-node markers matches insertion sequence", async ({ page }) => {
     // Insert first task (Call Task — index 0 in menu) on the start→end edge.
     await insertTaskViaAffordance(page, 0, 0);
 

--- a/tests/integration/insertion-layout-helpers.spec.ts
+++ b/tests/integration/insertion-layout-helpers.spec.ts
@@ -7,7 +7,7 @@
  * @module
  */
 
-import { INITIAL_EDGE_ID, START_NODE_ID, END_NODE_ID } from "@sw-editor/editor-core";
+import { END_NODE_ID, INITIAL_EDGE_ID, START_NODE_ID } from "@sw-editor/editor-core";
 import { describe, expect, it } from "vitest";
 
 import {

--- a/tests/integration/insertion-layout.helpers.ts
+++ b/tests/integration/insertion-layout.helpers.ts
@@ -12,15 +12,14 @@ import { extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  bootstrapWorkflowGraph,
   type InsertTaskResult,
+  insertTask,
+  parseWorkflowSource,
+  projectWorkflowToGraph,
   RevisionCounter,
   type WorkflowGraph,
   type WorkflowSource,
-  bootstrapWorkflowGraph,
-  insertTask,
-  loadWorkflow,
-  projectWorkflowToGraph,
-  parseWorkflowSource,
 } from "@sw-editor/editor-core";
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/insertion-performance.spec.ts
+++ b/tests/integration/insertion-performance.spec.ts
@@ -13,15 +13,13 @@
  */
 
 import {
-  type GraphEdge,
-  type GraphNode,
-  type WorkflowGraph,
-  INITIAL_EDGE_ID,
-  START_NODE_ID,
-  END_NODE_ID,
-  RevisionCounter,
   bootstrapWorkflowGraph,
+  END_NODE_ID,
+  type GraphEdge,
+  INITIAL_EDGE_ID,
   insertTask,
+  RevisionCounter,
+  type WorkflowGraph,
 } from "@sw-editor/editor-core";
 import type { RendererEdgeAnchor } from "@sw-editor/editor-renderer-contract";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -210,9 +208,7 @@ function realignAnchorsAfterViewportTransform(
  */
 function measureInsertAndSettle(graph: WorkflowGraph): number {
   // Pick a random interior edge to insert on (avoid cross-edges for simplicity).
-  const linearEdges = graph.edges.filter(
-    (e) => !e.id.startsWith("cross-"),
-  );
+  const linearEdges = graph.edges.filter((e) => !e.id.startsWith("cross-"));
   const targetEdge = linearEdges[Math.floor(Math.random() * linearEdges.length)];
 
   const counter = new RevisionCounter();

--- a/tests/integration/insertion-renderer-matrix.spec.ts
+++ b/tests/integration/insertion-renderer-matrix.spec.ts
@@ -130,11 +130,11 @@ vi.mock("@xyflow/react", () => ({
 
 import {
   bootstrapWorkflowGraph,
+  END_NODE_ID,
   INITIAL_EDGE_ID,
   insertTask,
   RevisionCounter,
   START_NODE_ID,
-  END_NODE_ID,
 } from "@sw-editor/editor-core";
 import type {
   FocusTarget,
@@ -316,7 +316,7 @@ describe("Insertion renderer matrix", () => {
         const firstEdge = updatedGraph.edges.find((e) => e.source === START_NODE_ID);
         expect(firstEdge, "edge from start to new node must exist").toBeDefined();
 
-        const anchor = stub.getEdgeAnchor(updatedGraph, firstEdge!.id);
+        const anchor = stub.getEdgeAnchor(updatedGraph, firstEdge?.id);
         expect(anchor, "getEdgeAnchor must return an anchor for the edge").not.toBeNull();
 
         // Compute the expected midpoint from the linear layout.
@@ -325,16 +325,16 @@ describe("Insertion renderer matrix", () => {
         const expectedMidX = (startIndex * NODE_H_GAP + newNodeIndex * NODE_H_GAP) / 2;
         const expectedMidY = 0;
 
-        const dist = distance(anchor!.x, anchor!.y, expectedMidX, expectedMidY);
+        const dist = distance(anchor?.x, anchor?.y, expectedMidX, expectedMidY);
         expect(
           dist,
-          `Edge anchor midpoint (${anchor!.x}, ${anchor!.y}) is ${dist.toFixed(1)}px ` +
+          `Edge anchor midpoint (${anchor?.x}, ${anchor?.y}) is ${dist.toFixed(1)}px ` +
             `from expected (${expectedMidX}, ${expectedMidY}); tolerance is ${MIDPOINT_TOLERANCE_PX}px`,
         ).toBeLessThanOrEqual(MIDPOINT_TOLERANCE_PX);
 
         // Also verify the anchor references the correct node IDs.
-        expect(anchor!.sourceNodeId).toBe(START_NODE_ID);
-        expect(anchor!.targetNodeId).toBe(newNodeId);
+        expect(anchor?.sourceNodeId).toBe(START_NODE_ID);
+        expect(anchor?.targetNodeId).toBe(newNodeId);
       });
 
       it("edge anchor midpoint for second edge is within 12px tolerance", () => {
@@ -351,7 +351,7 @@ describe("Insertion renderer matrix", () => {
         const secondEdge = updatedGraph.edges.find((e) => e.target === END_NODE_ID);
         expect(secondEdge, "edge from new node to end must exist").toBeDefined();
 
-        const anchor = stub.getEdgeAnchor(updatedGraph, secondEdge!.id);
+        const anchor = stub.getEdgeAnchor(updatedGraph, secondEdge?.id);
         expect(anchor, "getEdgeAnchor must return an anchor").not.toBeNull();
 
         const newNodeIndex = updatedGraph.nodes.findIndex((n) => n.id === newNodeId);
@@ -359,14 +359,14 @@ describe("Insertion renderer matrix", () => {
         const expectedMidX = (newNodeIndex * NODE_H_GAP + endIndex * NODE_H_GAP) / 2;
         const expectedMidY = 0;
 
-        const dist = distance(anchor!.x, anchor!.y, expectedMidX, expectedMidY);
+        const dist = distance(anchor?.x, anchor?.y, expectedMidX, expectedMidY);
         expect(
           dist,
           `Edge anchor midpoint distance ${dist.toFixed(1)}px exceeds ${MIDPOINT_TOLERANCE_PX}px tolerance`,
         ).toBeLessThanOrEqual(MIDPOINT_TOLERANCE_PX);
 
-        expect(anchor!.sourceNodeId).toBe(newNodeId);
-        expect(anchor!.targetNodeId).toBe(END_NODE_ID);
+        expect(anchor?.sourceNodeId).toBe(newNodeId);
+        expect(anchor?.targetNodeId).toBe(END_NODE_ID);
       });
 
       it("focus lands on the newly inserted node", () => {
@@ -384,8 +384,8 @@ describe("Insertion renderer matrix", () => {
         stub.focusNode({ nodeId: newNodeId, behavior: "center" });
 
         expect(stub.lastFocusTarget, "focusNode must have been called").not.toBeNull();
-        expect(stub.lastFocusTarget!.nodeId).toBe(newNodeId);
-        expect(stub.lastFocusTarget!.behavior).toBe("center");
+        expect(stub.lastFocusTarget?.nodeId).toBe(newNodeId);
+        expect(stub.lastFocusTarget?.behavior).toBe("center");
       });
 
       it("focus with ensure-visible behavior targets the correct node", () => {
@@ -399,8 +399,8 @@ describe("Insertion renderer matrix", () => {
         stub.focusNode({ nodeId: newNodeId, behavior: "ensure-visible" });
 
         expect(stub.lastFocusTarget).not.toBeNull();
-        expect(stub.lastFocusTarget!.nodeId).toBe(newNodeId);
-        expect(stub.lastFocusTarget!.behavior).toBe("ensure-visible");
+        expect(stub.lastFocusTarget?.nodeId).toBe(newNodeId);
+        expect(stub.lastFocusTarget?.behavior).toBe("ensure-visible");
       });
 
       it("getEdgeAnchor returns null for a non-existent edge", () => {
@@ -430,7 +430,7 @@ describe("Insertion renderer matrix", () => {
         expect(edgeToEnd).toBeDefined();
 
         const second = insertTask(first.graph, counter, {
-          edgeId: edgeToEnd!.id,
+          edgeId: edgeToEnd?.id,
           taskReference: "task2",
         });
 
@@ -448,7 +448,7 @@ describe("Insertion renderer matrix", () => {
           const expectedX = (srcIdx * NODE_H_GAP + tgtIdx * NODE_H_GAP) / 2;
           const expectedY = 0;
 
-          const dist = distance(anchor!.x, anchor!.y, expectedX, expectedY);
+          const dist = distance(anchor?.x, anchor?.y, expectedX, expectedY);
           expect(dist, `Edge ${edge.id} anchor midpoint exceeds tolerance`).toBeLessThanOrEqual(
             MIDPOINT_TOLERANCE_PX,
           );
@@ -456,7 +456,7 @@ describe("Insertion renderer matrix", () => {
 
         // Focus should target the second inserted node.
         stub.focusNode({ nodeId: second.nodeId, behavior: "center" });
-        expect(stub.lastFocusTarget!.nodeId).toBe(second.nodeId);
+        expect(stub.lastFocusTarget?.nodeId).toBe(second.nodeId);
       });
     });
   }

--- a/tests/integration/quickstart-scenarios.spec.ts
+++ b/tests/integration/quickstart-scenarios.spec.ts
@@ -612,8 +612,12 @@ describe("Quickstart Scenario 6 — Load, Insert, Verify Visual Order", () => {
     expect(nodeIds[1]).toBe(result.nodeId);
 
     // Verify the full connectivity chain: start → task → end.
-    const edgeToTask = result.graph.edges.find((e) => e.source === START_NODE_ID && e.target === result.nodeId);
-    const edgeFromTask = result.graph.edges.find((e) => e.source === result.nodeId && e.target === END_NODE_ID);
+    const edgeToTask = result.graph.edges.find(
+      (e) => e.source === START_NODE_ID && e.target === result.nodeId,
+    );
+    const edgeFromTask = result.graph.edges.find(
+      (e) => e.source === result.nodeId && e.target === END_NODE_ID,
+    );
     expect(edgeToTask).toBeDefined();
     expect(edgeFromTask).toBeDefined();
   });

--- a/tests/integration/repeated-insert-layout.spec.ts
+++ b/tests/integration/repeated-insert-layout.spec.ts
@@ -12,11 +12,11 @@
  */
 
 import {
-  INITIAL_EDGE_ID,
-  START_NODE_ID,
   END_NODE_ID,
+  INITIAL_EDGE_ID,
   insertTask,
   RevisionCounter,
+  START_NODE_ID,
 } from "@sw-editor/editor-core";
 import { describe, expect, it } from "vitest";
 
@@ -50,7 +50,7 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
       const edgeR1ToEnd = r1.graph.edges.find((e) => e.target === END_NODE_ID);
       expect(edgeR1ToEnd).toBeDefined();
       const r2 = insertTask(r1.graph, counter, {
-        edgeId: edgeR1ToEnd!.id,
+        edgeId: edgeR1ToEnd?.id,
         taskReference: "seqTask2",
       });
 
@@ -58,18 +58,12 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
       const edgeR2ToEnd = r2.graph.edges.find((e) => e.target === END_NODE_ID);
       expect(edgeR2ToEnd).toBeDefined();
       const r3 = insertTask(r2.graph, counter, {
-        edgeId: edgeR2ToEnd!.id,
+        edgeId: edgeR2ToEnd?.id,
         taskReference: "seqTask3",
       });
 
       // Final graph: start → r1 → r2 → r3 → end
-      assertNodeOrder(r3.graph, [
-        START_NODE_ID,
-        r1.nodeId,
-        r2.nodeId,
-        r3.nodeId,
-        END_NODE_ID,
-      ]);
+      assertNodeOrder(r3.graph, [START_NODE_ID, r1.nodeId, r2.nodeId, r3.nodeId, END_NODE_ID]);
 
       // Verify total counts.
       expect(r3.graph.nodes).toHaveLength(5);
@@ -90,21 +84,21 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
       const edgeStartToR1 = r1.graph.edges.find((e) => e.source === START_NODE_ID);
       expect(edgeStartToR1).toBeDefined();
       const r2 = insertTask(r1.graph, counter, {
-        edgeId: edgeStartToR1!.id,
+        edgeId: edgeStartToR1?.id,
         taskReference: "headTask2",
       });
 
       const edgeStartToR2 = r2.graph.edges.find((e) => e.source === START_NODE_ID);
       expect(edgeStartToR2).toBeDefined();
       const r3 = insertTask(r2.graph, counter, {
-        edgeId: edgeStartToR2!.id,
+        edgeId: edgeStartToR2?.id,
         taskReference: "headTask3",
       });
 
       const edgeStartToR3 = r3.graph.edges.find((e) => e.source === START_NODE_ID);
       expect(edgeStartToR3).toBeDefined();
       const r4 = insertTask(r3.graph, counter, {
-        edgeId: edgeStartToR3!.id,
+        edgeId: edgeStartToR3?.id,
         taskReference: "headTask4",
       });
 
@@ -138,19 +132,15 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
       graph = r1.graph;
       // Now: start → taskA → r1 → taskB → end
 
-      const edgeR1ToTaskB = graph.edges.find(
-        (e) => e.source === r1.nodeId && e.target === "taskB",
-      );
+      const edgeR1ToTaskB = graph.edges.find((e) => e.source === r1.nodeId && e.target === "taskB");
       expect(edgeR1ToTaskB).toBeDefined();
-      const r2 = insertTaskAtEdge(graph, edgeR1ToTaskB!.id, "midTask2");
+      const r2 = insertTaskAtEdge(graph, edgeR1ToTaskB?.id, "midTask2");
       graph = r2.graph;
       // Now: start → taskA → r1 → r2 → taskB → end
 
-      const edgeR2ToTaskB = graph.edges.find(
-        (e) => e.source === r2.nodeId && e.target === "taskB",
-      );
+      const edgeR2ToTaskB = graph.edges.find((e) => e.source === r2.nodeId && e.target === "taskB");
       expect(edgeR2ToTaskB).toBeDefined();
-      const r3 = insertTaskAtEdge(graph, edgeR2ToTaskB!.id, "midTask3");
+      const r3 = insertTaskAtEdge(graph, edgeR2ToTaskB?.id, "midTask3");
       graph = r3.graph;
 
       // Final: start → taskA → r1 → r2 → r3 → taskB → end
@@ -187,14 +177,14 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
       const edgeR1ToEnd = r1.graph.edges.find((e) => e.target === END_NODE_ID);
       expect(edgeR1ToEnd).toBeDefined();
       const r2 = insertTask(r1.graph, counter, {
-        edgeId: edgeR1ToEnd!.id,
+        edgeId: edgeR1ToEnd?.id,
         taskReference: "connTask2",
       });
 
       const edgeR2ToEnd = r2.graph.edges.find((e) => e.target === END_NODE_ID);
       expect(edgeR2ToEnd).toBeDefined();
       const r3 = insertTask(r2.graph, counter, {
-        edgeId: edgeR2ToEnd!.id,
+        edgeId: edgeR2ToEnd?.id,
         taskReference: "connTask3",
       });
 
@@ -209,10 +199,7 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
         const connectingEdges = finalGraph.edges.filter(
           (e) => e.source === src && e.target === tgt,
         );
-        expect(
-          connectingEdges,
-          `expected exactly one edge from ${src} to ${tgt}`,
-        ).toHaveLength(1);
+        expect(connectingEdges, `expected exactly one edge from ${src} to ${tgt}`).toHaveLength(1);
       }
 
       // No extra edges beyond the expected chain.
@@ -223,7 +210,7 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
       let graph = loadFixtureGraph("insert-layout-linear.json");
 
       // Original edges: start→taskA, taskA→taskB, taskB→end
-      const originalEdgeIds = new Set(graph.edges.map((e) => e.id));
+      const _originalEdgeIds = new Set(graph.edges.map((e) => e.id));
 
       const r1 = insertTaskAtEdge(graph, "taskA->taskB", "staleCheck1");
       graph = r1.graph;
@@ -237,17 +224,15 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
       expect(currentEdgeIds.has(`taskB->${END_NODE_ID}`)).toBe(true);
 
       // Insert another on r1→taskB edge.
-      const edgeR1ToTaskB = graph.edges.find(
-        (e) => e.source === r1.nodeId && e.target === "taskB",
-      );
+      const edgeR1ToTaskB = graph.edges.find((e) => e.source === r1.nodeId && e.target === "taskB");
       expect(edgeR1ToTaskB).toBeDefined();
 
-      const r2 = insertTaskAtEdge(graph, edgeR1ToTaskB!.id, "staleCheck2");
+      const r2 = insertTaskAtEdge(graph, edgeR1ToTaskB?.id, "staleCheck2");
       graph = r2.graph;
 
       // The r1→taskB edge should now be gone.
       const finalEdgeIds = new Set(graph.edges.map((e) => e.id));
-      expect(finalEdgeIds.has(edgeR1ToTaskB!.id)).toBe(false);
+      expect(finalEdgeIds.has(edgeR1ToTaskB?.id)).toBe(false);
 
       // All remaining edges should reference nodes that exist in the graph.
       const nodeIds = new Set(graph.nodes.map((n) => n.id));
@@ -284,7 +269,7 @@ describe("repeated-insert-layout — US3: repeated adjacent insertions remain re
         const edgeToEnd = current.edges.find((e) => e.target === END_NODE_ID);
         expect(edgeToEnd).toBeDefined();
         const result = insertTask(current, counter, {
-          edgeId: edgeToEnd!.id,
+          edgeId: edgeToEnd?.id,
           taskReference: `overlapTask${i}`,
         });
         current = result.graph;


### PR DESCRIPTION
## Summary

- Ran `biome check .` and fixed all lint, format, and import organization violations across the codebase
- Replaced non-null assertions (`!`) with safe alternatives in `react-flow-adapter.ts`
- Removed unused variables in test files
- Added `biome-ignore` for one case where TypeScript requires bracket notation on `dataset` index signatures
- All 13 affected files now pass `biome check .` with zero warnings

Closes #262

## Test plan

- [x] `pnpm lint` passes with no violations
- [x] `pnpm build` succeeds
- [x] `pnpm test` — all 205 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)